### PR TITLE
Add a new option during builder setup: 'Use single field'

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -11,17 +11,23 @@
           </ul>
         ]]>
     </description>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <change-notes>
         <![CDATA[
+           version 1.1.5
+           <br/>
+           <ul>
+           <li>Added ability to generate builder using a single field (the object to be built itself) instead of all fields of the object to be built</li>
+           </ul>
            version 1.1.4
            <br/>
            <ul>
-           <li>Ignore serialVersionUID field <a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/31">(issue #31)</li>
+           <li>Ignore serialVersionUID field <a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/31">(issue #31)</a></li>
+           </ul>
            version 1.1.3
            <br/>
            <ul>
-           <li>Fix incompatibility with IntelliJ 2017.1 <a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/33">(issue #33)</li>
+           <li>Fix incompatibility with IntelliJ 2017.1 <a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/33">(issue #33)</a></li>
            </ul>
            version 1.1.2
            <br/>

--- a/README
+++ b/README
@@ -4,5 +4,6 @@ Generated builder class does not use reflection, only setter methods or construc
 Requires gradle and IntelliJ IDEA for building.
 Build instructions:
 - edit build.gradle and change values of 'ideaInstallationPath' and 'ideaJdk' to be in sync with your environment
+- edit build.gradle and change "from('/META-INF')" to "from('./META-INF')" if using linux as dev environment
 - invoke 'gradle build' from command line to build
 - invoke 'gradle idea' from command line to generate IDEA specific files - provides possibility to be opened as IDEA project (open builder-generator-idea-plugin.ipr)

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosersRunnable.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosersRunnable.java
@@ -63,7 +63,7 @@ public class DisplayChoosersRunnable implements Runnable {
             List<PsiElementClassMember> selectedElements = memberChooserDialog.getSelectedElements();
             PsiFieldsForBuilder psiFieldsForBuilder = psiFieldsForBuilderFactory.createPsiFieldsForBuilder(selectedElements, psiClassFromEditor);
             BuilderContext context = new BuilderContext(
-                    project, psiFieldsForBuilder, targetDirectory, className, psiClassFromEditor, methodPrefix, createBuilderDialog.isInnerBuilder(), createBuilderDialog.hasButMethod());
+                    project, psiFieldsForBuilder, targetDirectory, className, psiClassFromEditor, methodPrefix, createBuilderDialog.isInnerBuilder(), createBuilderDialog.hasButMethod(), createBuilderDialog.useSingleField());
             builderWriter.writeBuilder(context);
         }
     }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosersRunnable.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosersRunnable.java
@@ -50,7 +50,9 @@ public class DisplayChoosersRunnable implements Runnable {
             String className = createBuilderDialog.getClassName();
             String methodPrefix = createBuilderDialog.getMethodPrefix();
             boolean innerBuilder = createBuilderDialog.isInnerBuilder();
-            List<PsiElementClassMember> fieldsToDisplay = getFieldsToIncludeInBuilder(psiClassFromEditor, innerBuilder);
+            boolean useSingleField = createBuilderDialog.useSingleField();
+            boolean hasButMethod = createBuilderDialog.hasButMethod();
+            List<PsiElementClassMember> fieldsToDisplay = getFieldsToIncludeInBuilder(psiClassFromEditor, innerBuilder, useSingleField, hasButMethod);
             MemberChooser<PsiElementClassMember> memberChooserDialog = memberChooserDialogFactory.getMemberChooserDialog(fieldsToDisplay, project);
             memberChooserDialog.show();
             writeBuilderIfNecessary(targetDirectory, className, methodPrefix, memberChooserDialog, createBuilderDialog);
@@ -76,8 +78,8 @@ public class DisplayChoosersRunnable implements Runnable {
         return dialog;
     }
 
-    private List<PsiElementClassMember> getFieldsToIncludeInBuilder(PsiClass clazz, boolean innerBuilder) {
-        return psiFieldSelector.selectFieldsToIncludeInBuilder(clazz, innerBuilder);
+    private List<PsiElementClassMember> getFieldsToIncludeInBuilder(PsiClass clazz, boolean innerBuilder, boolean useSingleField, boolean hasButMethod) {
+        return psiFieldSelector.selectFieldsToIncludeInBuilder(clazz, innerBuilder, useSingleField, hasButMethod);
     }
 
     public void setPsiClassFromEditor(PsiClass psiClassFromEditor) {

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialog.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialog.java
@@ -45,16 +45,16 @@ public class CreateBuilderDialog extends DialogWrapper {
     static final String RECENTS_KEY = "CreateBuilderDialog.RecentsKey";
     private static final int WIDTH = 40;
 
-    private PsiHelper                            psiHelper;
-    private GuiHelper                            guiHelper;
-    private Project                              project;
-    private PsiDirectory                         targetDirectory;
-    private PsiClass                             sourceClass;
-    private JTextField                           targetClassNameField;
-    private JTextField                           targetMethodPrefix;
-    private JCheckBox                            innerBuilder;
-    private JCheckBox                            butMethod;
-    private JCheckBox                            useSingleField;
+    private PsiHelper psiHelper;
+    private GuiHelper guiHelper;
+    private Project project;
+    private PsiDirectory targetDirectory;
+    private PsiClass sourceClass;
+    private JTextField targetClassNameField;
+    private JTextField targetMethodPrefix;
+    private JCheckBox innerBuilder;
+    private JCheckBox butMethod;
+    private JCheckBox useSingleField;
     private ReferenceEditorComboWithBrowseButton targetPackageField;
 
     public CreateBuilderDialog(Project project,

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialog.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialog.java
@@ -45,15 +45,16 @@ public class CreateBuilderDialog extends DialogWrapper {
     static final String RECENTS_KEY = "CreateBuilderDialog.RecentsKey";
     private static final int WIDTH = 40;
 
-    private PsiHelper psiHelper;
-    private GuiHelper guiHelper;
-    private Project project;
-    private PsiDirectory targetDirectory;
-    private PsiClass sourceClass;
-    private JTextField targetClassNameField;
-    private JTextField targetMethodPrefix;
-    private JCheckBox innerBuilder;
-    private JCheckBox butMethod;
+    private PsiHelper                            psiHelper;
+    private GuiHelper                            guiHelper;
+    private Project                              project;
+    private PsiDirectory                         targetDirectory;
+    private PsiClass                             sourceClass;
+    private JTextField                           targetClassNameField;
+    private JTextField                           targetMethodPrefix;
+    private JCheckBox                            innerBuilder;
+    private JCheckBox                            butMethod;
+    private JCheckBox                            useSingleField;
     private ReferenceEditorComboWithBrowseButton targetPackageField;
 
     public CreateBuilderDialog(Project project,
@@ -213,6 +214,26 @@ public class CreateBuilderDialog extends DialogWrapper {
         panel.add(butMethod, gbConstraints);
         // but method
 
+
+        // useSingleField
+        gbConstraints.insets = new Insets(4, 8, 4, 8);
+        gbConstraints.gridx = 0;
+        gbConstraints.weightx = 0;
+        gbConstraints.gridy = 6;
+        gbConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gbConstraints.anchor = GridBagConstraints.WEST;
+        panel.add(new JLabel("Use single field"), gbConstraints);
+
+        gbConstraints.insets = new Insets(4, 8, 4, 8);
+        gbConstraints.gridx = 1;
+        gbConstraints.weightx = 1;
+        gbConstraints.gridwidth = 1;
+        gbConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gbConstraints.anchor = GridBagConstraints.WEST;
+        useSingleField = new JCheckBox();
+        panel.add(useSingleField, gbConstraints);
+        // useSingleField
+
         return panel;
     }
 
@@ -275,6 +296,10 @@ public class CreateBuilderDialog extends DialogWrapper {
 
     public boolean hasButMethod() {
         return butMethod.isSelected();
+    }
+
+    public boolean useSingleField() {
+        return useSingleField.isSelected();
     }
 
     public PsiDirectory getTargetDirectory() {

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilder.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilder.java
@@ -1,12 +1,5 @@
 package pl.mjedynak.idea.plugins.builder.psi;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-
-import static com.intellij.openapi.util.text.StringUtil.isVowel;
 import com.intellij.psi.JavaDirectoryService;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClass;
@@ -17,6 +10,14 @@ import com.intellij.psi.PsiModifierList;
 import org.apache.commons.lang.StringUtils;
 import pl.mjedynak.idea.plugins.builder.settings.CodeStyleSettings;
 import pl.mjedynak.idea.plugins.builder.writer.BuilderContext;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import static com.intellij.openapi.util.text.StringUtil.isVowel;
 
 public class BuilderPsiClassBuilder {
 

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/ButMethodCreator.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/ButMethodCreator.java
@@ -4,7 +4,7 @@ import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElementFactory;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiParameterList;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import pl.mjedynak.idea.plugins.builder.settings.CodeStyleSettings;
 
 public class ButMethodCreator {

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/MethodCreator.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/MethodCreator.java
@@ -17,7 +17,7 @@ public class MethodCreator {
         this.builderClassName = builderClassName;
     }
 
-    public PsiMethod createMethod(PsiField psiField, String methodPrefix) {
+    public PsiMethod createMethod(PsiField psiField, String methodPrefix, String srcClassFieldName, boolean useSingleField) {
         String fieldName = psiField.getName();
         String fieldType = psiField.getType().getPresentableText();
         String fieldNamePrefix = codeStyleSettings.getFieldNamePrefix();
@@ -25,8 +25,15 @@ public class MethodCreator {
         String parameterNamePrefix = codeStyleSettings.getParameterNamePrefix();
         String parameterName = parameterNamePrefix + fieldNameWithoutPrefix;
         String methodName = methodNameCreator.createMethodName(methodPrefix, fieldNameWithoutPrefix);
-        String methodText = "public " + builderClassName + " " + methodName + "(" + fieldType + " " + parameterName + ") { this."
+        String methodText;
+        if(useSingleField){
+            String setterName = methodNameCreator.createMethodName("set", fieldNameWithoutPrefix);
+            methodText = "public " + builderClassName + " " + methodName + "(" + fieldType + " " + parameterName + ") { "
+                + srcClassFieldName + "." + setterName + "(" + fieldName + "); return this; }";
+        } else {
+            methodText = "public " + builderClassName + " " + methodName + "(" + fieldType + " " + parameterName + ") { this."
                 + fieldName + " = " + parameterName + "; return this; }";
+        }
         return elementFactory.createMethodFromText(methodText, psiField);
     }
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/PsiFieldSelector.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/PsiFieldSelector.java
@@ -22,11 +22,11 @@ public class PsiFieldSelector {
         this.psiFieldVerifier = psiFieldVerifier;
     }
 
-    public List<PsiElementClassMember> selectFieldsToIncludeInBuilder(final PsiClass psiClass, final boolean innerBuilder) {
+    public List<PsiElementClassMember> selectFieldsToIncludeInBuilder(final PsiClass psiClass, final boolean innerBuilder, final boolean useSingleField, final boolean hasButMethod) {
         List<PsiElementClassMember> result = new ArrayList<>();
 
         List<PsiField> psiFields = stream(psiClass.getAllFields()).filter(psiField -> !"serialVersionUID".equals(psiField.getName())).collect(toList());
-        Iterable<PsiField> filtered = psiFields.stream().filter(psiField -> innerBuilder || isAppropriate(psiClass, psiField)).collect(toList());
+        Iterable<PsiField> filtered = psiFields.stream().filter(psiField -> isAppropriate(psiClass, psiField, innerBuilder, useSingleField, hasButMethod)).collect(toList());
 
         for (PsiField psiField : filtered) {
             result.add(psiElementClassMemberFactory.createPsiElementClassMember(psiField));
@@ -34,9 +34,14 @@ public class PsiFieldSelector {
         return result;
     }
 
-    private boolean isAppropriate(PsiClass psiClass, PsiField psiField) {
-        return psiFieldVerifier.isSetInSetterMethod(psiField, psiClass) || psiFieldVerifier.isSetInConstructor(psiField, psiClass);
+    private boolean isAppropriate(PsiClass psiClass, PsiField psiField, boolean innerBuilder, boolean useSingleField, boolean hasButMethod) {
+        if(useSingleField && hasButMethod) {
+            return psiFieldVerifier.isSetInSetterMethod(psiField, psiClass) && psiFieldVerifier.hasGetterMethod(psiField, psiClass);
+        } else if(useSingleField){
+            return psiFieldVerifier.isSetInSetterMethod(psiField, psiClass);
+        } else if(!innerBuilder){
+            return psiFieldVerifier.isSetInSetterMethod(psiField, psiClass) || psiFieldVerifier.isSetInConstructor(psiField, psiClass);
+        }
+        return true;
     }
-
-
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/verifier/PsiFieldVerifier.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/verifier/PsiFieldVerifier.java
@@ -15,6 +15,7 @@ public class PsiFieldVerifier {
 
     static final String PRIVATE_MODIFIER = "private";
     static final String SET_PREFIX = "set";
+    static final String GET_PREFIX = "get";
 
     private CodeStyleSettings codeStyleSettings = new CodeStyleSettings();
 
@@ -60,9 +61,17 @@ public class PsiFieldVerifier {
     }
 
     public boolean isSetInSetterMethod(PsiField psiField, PsiClass psiClass) {
+        return methodIsNotPrivateAndHasProperPrefixAndProperName(psiField, psiClass, SET_PREFIX);
+    }
+
+    public boolean hasGetterMethod(PsiField psiField, PsiClass psiClass) {
+        return methodIsNotPrivateAndHasProperPrefixAndProperName(psiField, psiClass, GET_PREFIX);
+    }
+
+    private boolean methodIsNotPrivateAndHasProperPrefixAndProperName(PsiField psiField, PsiClass psiClass, String prefix) {
         boolean result = false;
         for (PsiMethod method : psiClass.getAllMethods()) {
-            if (methodIsNotPrivate(method) && methodIsSetterWithProperName(psiField, method)) {
+            if (methodIsNotPrivate(method) && methodHaProperPrefixAndProperName(psiField, method, prefix)) {
                 result = true;
                 break;
             }
@@ -75,10 +84,10 @@ public class PsiFieldVerifier {
         return modifierListHasNoPrivateModifier(modifierList);
     }
 
-    private boolean methodIsSetterWithProperName(PsiField psiField, PsiMethod method) {
+    private boolean methodHaProperPrefixAndProperName(PsiField psiField, PsiMethod method, String prefix) {
         String fieldNamePrefix = codeStyleSettings.getFieldNamePrefix();
         String fieldNameWithoutPrefix = psiField.getName().replace(fieldNamePrefix, EMPTY);
-        return method.getName().equals(SET_PREFIX + WordUtils.capitalize(fieldNameWithoutPrefix));
+        return method.getName().equals(prefix + WordUtils.capitalize(fieldNameWithoutPrefix));
     }
 
     private boolean modifierListHasNoPrivateModifier(PsiModifierList modifierList) {

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderContext.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderContext.java
@@ -16,10 +16,11 @@ public class BuilderContext {
     private final String methodPrefix;
     private final boolean isInner;
     private final boolean hasButMethod;
+    private final boolean useSingleField;
 
     public BuilderContext(Project project, PsiFieldsForBuilder psiFieldsForBuilder,
                           PsiDirectory targetDirectory, String className, PsiClass psiClassFromEditor,
-                          String methodPrefix, boolean isInner, boolean hasButMethod) {
+                          String methodPrefix, boolean isInner, boolean hasButMethod, boolean useSingleField) {
         this.project = project;
         this.psiFieldsForBuilder = psiFieldsForBuilder;
         this.targetDirectory = targetDirectory;
@@ -28,6 +29,7 @@ public class BuilderContext {
         this.methodPrefix = methodPrefix;
         this.isInner = isInner;
         this.hasButMethod = hasButMethod;
+        this.useSingleField = useSingleField;
     }
 
     public Project getProject() {
@@ -60,6 +62,10 @@ public class BuilderContext {
 
     boolean hasButMethod() {
         return hasButMethod;
+    }
+
+    public boolean useSingleField() {
+        return useSingleField;
     }
 
     @Override

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosersRunnableTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosersRunnableTest.java
@@ -1,12 +1,5 @@
 package pl.mjedynak.idea.plugins.builder.action.handler;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import com.intellij.codeInsight.generation.PsiElementClassMember;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
@@ -33,6 +26,14 @@ import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 import pl.mjedynak.idea.plugins.builder.psi.model.PsiFieldsForBuilder;
 import pl.mjedynak.idea.plugins.builder.writer.BuilderContext;
 import pl.mjedynak.idea.plugins.builder.writer.BuilderWriter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DisplayChoosersRunnableTest {
@@ -124,7 +125,7 @@ public class DisplayChoosersRunnableTest {
         given(createBuilderDialog.getMethodPrefix()).willReturn(methodPrefix);
         given(psiClassFromEditor.getAllFields()).willReturn(allFields);
         given(memberChooserDialogFactory.getMemberChooserDialog(selectedFields, project)).willReturn(memberChooserDialog);
-        given(psiFieldSelector.selectFieldsToIncludeInBuilder(psiClassFromEditor, false)).willReturn(selectedFields);
+        given(psiFieldSelector.selectFieldsToIncludeInBuilder(psiClassFromEditor, false, false, false)).willReturn(selectedFields);
         given(memberChooserDialog.getSelectedElements()).willReturn(selectedFields);
 
         // when

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosersRunnableTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosersRunnableTest.java
@@ -1,5 +1,12 @@
 package pl.mjedynak.idea.plugins.builder.action.handler;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import com.intellij.codeInsight.generation.PsiElementClassMember;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
@@ -15,21 +22,17 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import pl.mjedynak.idea.plugins.builder.factory.*;
+import pl.mjedynak.idea.plugins.builder.factory.CreateBuilderDialogFactory;
+import pl.mjedynak.idea.plugins.builder.factory.MemberChooser;
+import pl.mjedynak.idea.plugins.builder.factory.MemberChooserDialogFactory;
+import pl.mjedynak.idea.plugins.builder.factory.PsiFieldsForBuilderFactory;
+import pl.mjedynak.idea.plugins.builder.factory.PsiManagerFactory;
 import pl.mjedynak.idea.plugins.builder.gui.CreateBuilderDialog;
 import pl.mjedynak.idea.plugins.builder.psi.PsiFieldSelector;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 import pl.mjedynak.idea.plugins.builder.psi.model.PsiFieldsForBuilder;
 import pl.mjedynak.idea.plugins.builder.writer.BuilderContext;
 import pl.mjedynak.idea.plugins.builder.writer.BuilderWriter;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DisplayChoosersRunnableTest {
@@ -111,6 +114,7 @@ public class DisplayChoosersRunnableTest {
         String methodPrefix = "with";
         boolean isInner = true;
         boolean hasButMethod = true;
+        boolean useSingleField = true;
         given(createBuilderDialog.isInnerBuilder()).willReturn(isInner);
         given(createBuilderDialog.hasButMethod()).willReturn(hasButMethod);
         given(createBuilderDialog.isOK()).willReturn(true);
@@ -131,6 +135,6 @@ public class DisplayChoosersRunnableTest {
         verify(memberChooserDialog).isOK();
         verify(createBuilderDialog).show();
         verify(memberChooserDialog).show();
-        verify(builderWriter).writeBuilder(eq(new BuilderContext(project, psiFieldsForBuilder, psiDirectory, className, psiClassFromEditor, methodPrefix, isInner, hasButMethod)));
+        verify(builderWriter).writeBuilder(eq(new BuilderContext(project, psiFieldsForBuilder, psiDirectory, className, psiClassFromEditor, methodPrefix, isInner, hasButMethod, useSingleField)));
     }
 }

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/psi/ButMethodCreatorTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/psi/ButMethodCreatorTest.java
@@ -34,6 +34,8 @@ public class ButMethodCreatorTest {
     @Mock private PsiParameterList parameterList2;
     @Mock private PsiParameter parameter;
 
+    private String srcClassFieldName = "className";
+
     @Before
     public void mockCodeStyleManager() {
         given(settings.getFieldNamePrefix()).willReturn("m_");
@@ -41,9 +43,7 @@ public class ButMethodCreatorTest {
         setField(butMethodCreator, "codeStyleSettings", settings);
     }
 
-    @Test
-    public void shouldCreateButMethod() {
-        // given
+    private void initOtherCommonMocks() {
         given(builderClass.getMethods()).willReturn((PsiMethod[]) asList(method1, method2, method3).toArray());
         given(method1.getName()).willReturn("Builder");
         given(method2.getName()).willReturn("aBuilder");
@@ -54,11 +54,29 @@ public class ButMethodCreatorTest {
         given(parameterList2.getParametersCount()).willReturn(1);
         given(parameterList2.getParameters()).willReturn((PsiParameter[]) asList(parameter).toArray());
         given(parameter.getName()).willReturn("age");
+    }
 
-        given(psiElementFactory.createMethodFromText("public Builder but() { return aBuilder().withAge(m_age);}", srcClass)).willReturn(createdMethod);
+    @Test
+    public void shouldCreateButMethod() {
+        // given
+        initOtherCommonMocks();
+        given(psiElementFactory.createMethodFromText("public Builder but() { return aBuilder().withAge(m_age); }", srcClass)).willReturn(createdMethod);
 
         // when
-        PsiMethod result = butMethodCreator.butMethod("Builder", builderClass, srcClass);
+        PsiMethod result = butMethodCreator.butMethod("Builder", builderClass, srcClass, srcClassFieldName, false);
+
+        // then
+        assertThat(result).isEqualTo(createdMethod);
+    }
+
+    @Test
+    public void shouldCreateButMethodForSingleField() {
+        // given
+        initOtherCommonMocks();
+        given(psiElementFactory.createMethodFromText("public Builder but() { return aBuilder().withAge(className.getAge()); }", srcClass)).willReturn(createdMethod);
+
+        // when
+        PsiMethod result = butMethodCreator.butMethod("Builder", builderClass, srcClass, srcClassFieldName, true);
 
         // then
         assertThat(result).isEqualTo(createdMethod);

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/psi/MethodCreatorTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/psi/MethodCreatorTest.java
@@ -1,9 +1,5 @@
 package pl.mjedynak.idea.plugins.builder.psi;
 
-import static org.apache.commons.lang.StringUtils.EMPTY;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
 import com.intellij.psi.PsiElementFactory;
 import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiMethod;
@@ -14,6 +10,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import pl.mjedynak.idea.plugins.builder.settings.CodeStyleSettings;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MethodCreatorTest {

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/verifier/PsiFieldVerifierTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/verifier/PsiFieldVerifierTest.java
@@ -160,6 +160,50 @@ public class PsiFieldVerifierTest {
         assertThat(result).isFalse();
     }
 
+    @Test
+    public void shouldVerifyThatFieldHasGetterMethodAvailableIfTheMethodIsNotPrivateAndHasCorrectName() {
+        // given
+        given(psiClass.getAllMethods()).willReturn(methods);
+        given(method.getModifierList()).willReturn(modifierList);
+        given(psiField.getName()).willReturn("field");
+        given(method.getName()).willReturn("getField");
+
+        // when
+        boolean result = psiFieldVerifier.hasGetterMethod(psiField, psiClass);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void shouldVerifyThatFieldHasNoGetterMethodAvailableIfTheMethodIsPrivate() {
+        // given
+        given(psiClass.getAllMethods()).willReturn(methods);
+        given(method.getModifierList()).willReturn(modifierList);
+        given(psiField.getName()).willReturn("field");
+        given(modifierList.hasExplicitModifier(PsiFieldVerifier.PRIVATE_MODIFIER)).willReturn(true);
+        given(method.getName()).willReturn("setField");
+        // when
+        boolean result = psiFieldVerifier.hasGetterMethod(psiField, psiClass);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void shouldVerifyThatFieldHasNoGetterMethodAvailableIfTheMethodIsNotPrivateButHasIncorrectName() {
+        // given
+        given(psiClass.getAllMethods()).willReturn(methods);
+        given(method.getModifierList()).willReturn(modifierList);
+        given(psiField.getName()).willReturn("field");
+        given(method.getName()).willReturn("getAnotherField");
+        // when
+        boolean result = psiFieldVerifier.hasGetterMethod(psiField, psiClass);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
     private void prepareBehaviourForReturningParameter() {
         given(psiClass.getConstructors()).willReturn(constructors);
         given(constructor.getParameterList()).willReturn(parameterList);


### PR DESCRIPTION
So that the builder has a single field: the object to be built itself, instead of all fields of the object to be built. This requires less work to maintain builder when adding extra fields afterwards.