### PR TITLE
Adds the ability to regenerate an existing builder

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -7,13 +7,28 @@
          Generated builder class does not use reflection, only setter methods or constructor.
          Usage:
           <ul>
-              <li>ALT+SHIFT+B inside a class.</li>
+              <li>ALT+SHIFT+B inside a file:</li>
+              <ul>
+                  <li>creates a builder if it does not exist</li>
+                  <li>switches between class and builder if builder exists</li>
+               </ul>
+              <li><strong>Code | Generate</strong> menu (ALT+Insert) from a class:</li>
+              <ul>
+                  <li>creates a builder if it does not exist</li>
+                  <li>regenerates builder if it exists</li>
+              </ul>
           </ul>
         ]]>
     </description>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
     <change-notes>
         <![CDATA[
+           version 1.1.6
+           <br/>
+           <ul>
+           <li>Added ability to regenerate an existing builder, by automatically deleting the previous builder and creating a new one</li>
+           <li>Builder Generator is now also available from <strong>Code | Generate</strong> menu</li>
+           </ul>
            version 1.1.5
            <br/>
            <ul>
@@ -124,10 +139,14 @@
 
     <actions>
         <action id="GoToBuilder" class="pl.mjedynak.idea.plugins.builder.action.GoToBuilderAction"
-                text="Builder" description="Generates Builder">
+                text="Builder" description="Goes to/Generates Builder">
             <add-to-group group-id="GoToCodeGroup" anchor="after" relative-to-action="GotoTest"/>
             <add-to-group group-id="EditorPopupMenu.GoTo" anchor="last"/>
             <keyboard-shortcut keymap="$default" first-keystroke="shift alt B"/>
+        </action>
+        <action id="GenerateBuilder" class="pl.mjedynak.idea.plugins.builder.action.GenerateBuilderAction"
+                text="Builder" description="Generates/Regenerates Builder">
+            <add-to-group group-id="JavaGenerateGroup1" anchor="before" relative-to-action="GenerateEquals"/>
         </action>
     </actions>
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -70,7 +70,7 @@
        <property name="maximum" value="0"/>
        <property name="message" value="Line has trailing spaces."/>
     </module>
-
+    <module name="SuppressWarningsFilter" />
     <module name="TreeWalker">
 
         <!-- Checks for Javadoc comments.                     -->
@@ -176,7 +176,9 @@
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>
-        <module name="VisibilityModifier"/>
+        <module name="VisibilityModifier">
+            <property name="protectedAllowed" value="true"/>
+        </module>
 
 
         <!-- Miscellaneous other checks.                   -->
@@ -185,7 +187,7 @@
         <!--<module name="FinalParameters"/>-->
         <module name="TodoComment"/>
         <module name="UpperEll"/>
-
+        <module name="SuppressWarningsHolder" />
 
     </module>
 

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/AbstractBuilderAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/AbstractBuilderAction.java
@@ -1,0 +1,54 @@
+package pl.mjedynak.idea.plugins.builder.action;
+
+import com.intellij.openapi.editor.actionSystem.EditorAction;
+import org.picocontainer.MutablePicoContainer;
+import org.picocontainer.defaults.DefaultPicoContainer;
+import pl.mjedynak.idea.plugins.builder.action.handler.AbstractBuilderActionHandler;
+import pl.mjedynak.idea.plugins.builder.action.handler.DisplayChoosers;
+import pl.mjedynak.idea.plugins.builder.factory.CreateBuilderDialogFactory;
+import pl.mjedynak.idea.plugins.builder.factory.MemberChooserDialogFactory;
+import pl.mjedynak.idea.plugins.builder.factory.PopupChooserBuilderFactory;
+import pl.mjedynak.idea.plugins.builder.factory.PsiElementClassMemberFactory;
+import pl.mjedynak.idea.plugins.builder.factory.PsiFieldsForBuilderFactory;
+import pl.mjedynak.idea.plugins.builder.factory.PsiManagerFactory;
+import pl.mjedynak.idea.plugins.builder.factory.ReferenceEditorComboWithBrowseButtonFactory;
+import pl.mjedynak.idea.plugins.builder.finder.BuilderFinder;
+import pl.mjedynak.idea.plugins.builder.finder.ClassFinder;
+import pl.mjedynak.idea.plugins.builder.gui.helper.GuiHelper;
+import pl.mjedynak.idea.plugins.builder.psi.BuilderPsiClassBuilder;
+import pl.mjedynak.idea.plugins.builder.psi.PsiFieldSelector;
+import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
+import pl.mjedynak.idea.plugins.builder.verifier.BuilderVerifier;
+import pl.mjedynak.idea.plugins.builder.verifier.PsiFieldVerifier;
+import pl.mjedynak.idea.plugins.builder.writer.BuilderWriter;
+
+public abstract class AbstractBuilderAction extends EditorAction {
+
+    protected static AbstractBuilderActionHandler builderActionHandler;
+
+    protected static MutablePicoContainer picoContainer = new DefaultPicoContainer();
+
+    static {
+        picoContainer.registerComponentImplementation(PsiHelper.class);
+        picoContainer.registerComponentImplementation(BuilderVerifier.class);
+        picoContainer.registerComponentImplementation(ClassFinder.class);
+        picoContainer.registerComponentImplementation(BuilderPsiClassBuilder.class);
+        picoContainer.registerComponentImplementation(BuilderFinder.class);
+        picoContainer.registerComponentImplementation(PopupChooserBuilderFactory.class);
+        picoContainer.registerComponentImplementation(PsiManagerFactory.class);
+        picoContainer.registerComponentImplementation(CreateBuilderDialogFactory.class);
+        picoContainer.registerComponentImplementation(GuiHelper.class);
+        picoContainer.registerComponentImplementation(PsiFieldVerifier.class);
+        picoContainer.registerComponentImplementation(PsiElementClassMemberFactory.class);
+        picoContainer.registerComponentImplementation(ReferenceEditorComboWithBrowseButtonFactory.class);
+        picoContainer.registerComponentImplementation(MemberChooserDialogFactory.class);
+        picoContainer.registerComponentImplementation(BuilderWriter.class);
+        picoContainer.registerComponentImplementation(PsiFieldSelector.class);
+        picoContainer.registerComponentImplementation(PsiFieldsForBuilderFactory.class);
+        picoContainer.registerComponentImplementation(DisplayChoosers.class);
+    }
+
+    protected AbstractBuilderAction() {
+        super(builderActionHandler);
+    }
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/AbstractBuilderAdditionalAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/AbstractBuilderAdditionalAction.java
@@ -1,0 +1,7 @@
+package pl.mjedynak.idea.plugins.builder.action;
+
+import com.intellij.codeInsight.navigation.GotoTargetHandler;
+
+public abstract class AbstractBuilderAdditionalAction implements GotoTargetHandler.AdditionalAction {
+
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/GenerateBuilderAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/GenerateBuilderAction.java
@@ -1,0 +1,16 @@
+package pl.mjedynak.idea.plugins.builder.action;
+
+import pl.mjedynak.idea.plugins.builder.action.handler.AbstractBuilderActionHandler;
+import pl.mjedynak.idea.plugins.builder.action.handler.GenerateBuilderActionHandler;
+import pl.mjedynak.idea.plugins.builder.factory.GenerateBuilderPopupListFactory;
+import pl.mjedynak.idea.plugins.builder.gui.displayer.GenerateBuilderPopupDisplayer;
+
+public class GenerateBuilderAction extends AbstractBuilderAction {
+
+    static {
+        picoContainer.registerComponentImplementation(GenerateBuilderActionHandler.class);
+        picoContainer.registerComponentImplementation(GenerateBuilderPopupDisplayer.class);
+        picoContainer.registerComponentImplementation(GenerateBuilderPopupListFactory.class);
+        builderActionHandler = (AbstractBuilderActionHandler) picoContainer.getComponentInstanceOfType(GenerateBuilderActionHandler.class);
+    }
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/GenerateBuilderAdditionalAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/GenerateBuilderAdditionalAction.java
@@ -5,9 +5,9 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Icon;
 
-public class GoToBuilderAdditionalAction extends AbstractBuilderAdditionalAction {
+public class GenerateBuilderAdditionalAction extends AbstractBuilderAdditionalAction {
 
-    private static final String TEXT = "Go to builder...";
+    private static final String TEXT = "Create New Builder...";
     private static final Icon ICON = IconLoader.getIcon("/actions/intentionBulb.png");
 
     @NotNull

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/GoToBuilderAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/GoToBuilderAction.java
@@ -1,63 +1,16 @@
 package pl.mjedynak.idea.plugins.builder.action;
 
-import com.intellij.openapi.editor.actionSystem.EditorAction;
-import org.picocontainer.MutablePicoContainer;
-import org.picocontainer.defaults.DefaultPicoContainer;
-import pl.mjedynak.idea.plugins.builder.action.handler.DisplayChoosersRunnable;
+import pl.mjedynak.idea.plugins.builder.action.handler.AbstractBuilderActionHandler;
 import pl.mjedynak.idea.plugins.builder.action.handler.GoToBuilderActionHandler;
-import pl.mjedynak.idea.plugins.builder.factory.CreateBuilderDialogFactory;
-import pl.mjedynak.idea.plugins.builder.factory.MemberChooserDialogFactory;
-import pl.mjedynak.idea.plugins.builder.factory.PopupChooserBuilderFactory;
-import pl.mjedynak.idea.plugins.builder.factory.PopupListFactory;
-import pl.mjedynak.idea.plugins.builder.factory.PsiElementClassMemberFactory;
-import pl.mjedynak.idea.plugins.builder.factory.PsiFieldsForBuilderFactory;
-import pl.mjedynak.idea.plugins.builder.factory.PsiManagerFactory;
-import pl.mjedynak.idea.plugins.builder.factory.ReferenceEditorComboWithBrowseButtonFactory;
-import pl.mjedynak.idea.plugins.builder.finder.BuilderFinder;
-import pl.mjedynak.idea.plugins.builder.finder.ClassFinder;
-import pl.mjedynak.idea.plugins.builder.gui.displayer.PopupDisplayer;
-import pl.mjedynak.idea.plugins.builder.gui.helper.GuiHelper;
-import pl.mjedynak.idea.plugins.builder.psi.BuilderPsiClassBuilder;
-import pl.mjedynak.idea.plugins.builder.psi.PsiFieldSelector;
-import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
-import pl.mjedynak.idea.plugins.builder.verifier.BuilderVerifier;
-import pl.mjedynak.idea.plugins.builder.verifier.PsiFieldVerifier;
-import pl.mjedynak.idea.plugins.builder.writer.BuilderWriter;
+import pl.mjedynak.idea.plugins.builder.factory.GoToBuilderPopupListFactory;
+import pl.mjedynak.idea.plugins.builder.gui.displayer.GoToBuilderPopupDisplayer;
 
-
-public class GoToBuilderAction extends EditorAction {
-
-    private static GoToBuilderActionHandler goToBuilderActionHandler;
-
-    private static MutablePicoContainer picoContainer = new DefaultPicoContainer();
+public class GoToBuilderAction extends AbstractBuilderAction {
 
     static {
-        picoContainer.registerComponentImplementation(PsiHelper.class);
-        picoContainer.registerComponentImplementation(BuilderVerifier.class);
-        picoContainer.registerComponentImplementation(ClassFinder.class);
-        picoContainer.registerComponentImplementation(BuilderPsiClassBuilder.class);
-        picoContainer.registerComponentImplementation(BuilderFinder.class);
-        picoContainer.registerComponentImplementation(PopupChooserBuilderFactory.class);
-        picoContainer.registerComponentImplementation(PopupDisplayer.class);
-        picoContainer.registerComponentImplementation(PopupListFactory.class);
-        picoContainer.registerComponentImplementation(PsiManagerFactory.class);
-        picoContainer.registerComponentImplementation(CreateBuilderDialogFactory.class);
-        picoContainer.registerComponentImplementation(GuiHelper.class);
-        picoContainer.registerComponentImplementation(PsiFieldVerifier.class);
-        picoContainer.registerComponentImplementation(PsiElementClassMemberFactory.class);
-        picoContainer.registerComponentImplementation(ReferenceEditorComboWithBrowseButtonFactory.class);
-        picoContainer.registerComponentImplementation(MemberChooserDialogFactory.class);
-        picoContainer.registerComponentImplementation(BuilderWriter.class);
-        picoContainer.registerComponentImplementation(PsiFieldSelector.class);
-        picoContainer.registerComponentImplementation(PsiFieldsForBuilderFactory.class);
         picoContainer.registerComponentImplementation(GoToBuilderActionHandler.class);
-        picoContainer.registerComponentImplementation(DisplayChoosersRunnable.class);
-
-        goToBuilderActionHandler = (GoToBuilderActionHandler) picoContainer.getComponentInstanceOfType(GoToBuilderActionHandler.class);
-    }
-
-
-    protected GoToBuilderAction() {
-        super(goToBuilderActionHandler);
+        picoContainer.registerComponentImplementation(GoToBuilderPopupDisplayer.class);
+        picoContainer.registerComponentImplementation(GoToBuilderPopupListFactory.class);
+        builderActionHandler = (AbstractBuilderActionHandler) picoContainer.getComponentInstanceOfType(GoToBuilderActionHandler.class);
     }
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/RegenerateBuilderAdditionalAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/RegenerateBuilderAdditionalAction.java
@@ -5,9 +5,9 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Icon;
 
-public class GoToBuilderAdditionalAction extends AbstractBuilderAdditionalAction {
+public class RegenerateBuilderAdditionalAction extends AbstractBuilderAdditionalAction {
 
-    private static final String TEXT = "Go to builder...";
+    private static final String TEXT = "Regenerate builder...";
     private static final Icon ICON = IconLoader.getIcon("/actions/intentionBulb.png");
 
     @NotNull

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/AbstractBuilderActionHandler.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/AbstractBuilderActionHandler.java
@@ -1,0 +1,72 @@
+package pl.mjedynak.idea.plugins.builder.action.handler;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.DataKeys;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.actionSystem.EditorActionHandler;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiClass;
+import pl.mjedynak.idea.plugins.builder.factory.AbstractPopupListFactory;
+import pl.mjedynak.idea.plugins.builder.finder.BuilderFinder;
+import pl.mjedynak.idea.plugins.builder.gui.displayer.AbstractPopupDisplayer;
+import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
+import pl.mjedynak.idea.plugins.builder.verifier.BuilderVerifier;
+
+public abstract class AbstractBuilderActionHandler extends EditorActionHandler {
+
+    protected PsiHelper psiHelper;
+    private BuilderVerifier builderVerifier;
+    private BuilderFinder builderFinder;
+    protected AbstractPopupDisplayer popupDisplayer;
+    protected AbstractPopupListFactory popupListFactory;
+    protected DisplayChoosers displayChoosers;
+
+    public AbstractBuilderActionHandler(PsiHelper psiHelper, BuilderVerifier builderVerifier, BuilderFinder builderFinder, AbstractPopupDisplayer popupDisplayer,
+                                        AbstractPopupListFactory popupListFactory, DisplayChoosers displayChoosers) {
+        this.psiHelper = psiHelper;
+        this.builderVerifier = builderVerifier;
+        this.builderFinder = builderFinder;
+        this.popupDisplayer = popupDisplayer;
+        this.popupListFactory = popupListFactory;
+        this.displayChoosers = displayChoosers;
+    }
+
+    @Override
+    public void execute(Editor editor, DataContext dataContext) {
+        Project project = (Project) dataContext.getData(DataKeys.PROJECT.getName());
+        PsiClass psiClassFromEditor = psiHelper.getPsiClassFromEditor(editor, project);
+        prepareDisplayChoosers(editor, psiClassFromEditor, dataContext);
+        if (psiClassFromEditor != null) {
+            forwardToSpecificAction(editor, psiClassFromEditor, dataContext);
+        }
+    }
+
+    private void prepareDisplayChoosers(Editor editor, PsiClass psiClassFromEditor, DataContext dataContext) {
+        Project project = (Project) dataContext.getData(DataKeys.PROJECT.getName());
+        displayChoosers.setEditor(editor);
+        displayChoosers.setProject(project);
+        displayChoosers.setPsiClassFromEditor(psiClassFromEditor);
+    }
+
+    private void forwardToSpecificAction(Editor editor, PsiClass psiClassFromEditor, DataContext dataContext) {
+        boolean isBuilder = builderVerifier.isBuilder(psiClassFromEditor);
+        PsiClass classToGo = findClassToGo(psiClassFromEditor, isBuilder);
+        if (classToGo != null) {
+            doActionWhenClassToGoIsFound(editor, psiClassFromEditor, dataContext, isBuilder, classToGo);
+        } else {
+            doActionWhenClassToGoIsNotFound(editor, psiClassFromEditor, dataContext, isBuilder);
+        }
+    }
+
+    private PsiClass findClassToGo(PsiClass psiClassFromEditor, boolean isBuilder) {
+        if (isBuilder) {
+            return builderFinder.findClassForBuilder(psiClassFromEditor);
+        }
+        return builderFinder.findBuilderForClass(psiClassFromEditor);
+    }
+
+    protected abstract void doActionWhenClassToGoIsFound(Editor editor, PsiClass psiClassFromEditor, DataContext dataContext, boolean isBuilder, PsiClass classToGo);
+
+    protected abstract void doActionWhenClassToGoIsNotFound(Editor editor, PsiClass psiClassFromEditor, DataContext dataContext, boolean isBuilder);
+
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/GenerateBuilderActionHandler.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/GenerateBuilderActionHandler.java
@@ -1,0 +1,47 @@
+package pl.mjedynak.idea.plugins.builder.action.handler;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiClass;
+import pl.mjedynak.idea.plugins.builder.action.GoToBuilderAdditionalAction;
+import pl.mjedynak.idea.plugins.builder.action.RegenerateBuilderAdditionalAction;
+import pl.mjedynak.idea.plugins.builder.factory.GenerateBuilderPopupListFactory;
+import pl.mjedynak.idea.plugins.builder.finder.BuilderFinder;
+import pl.mjedynak.idea.plugins.builder.gui.displayer.GenerateBuilderPopupDisplayer;
+import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
+import pl.mjedynak.idea.plugins.builder.verifier.BuilderVerifier;
+
+import javax.swing.JList;
+
+public class GenerateBuilderActionHandler extends AbstractBuilderActionHandler {
+
+    public GenerateBuilderActionHandler(PsiHelper psiHelper, BuilderVerifier builderVerifier, BuilderFinder builderFinder, GenerateBuilderPopupDisplayer popupDisplayer, GenerateBuilderPopupListFactory popupListFactory, DisplayChoosers displayChoosersRunnable) {
+        super(psiHelper, builderVerifier, builderFinder, popupDisplayer, popupListFactory, displayChoosersRunnable);
+    }
+
+    @Override
+    protected void doActionWhenClassToGoIsFound(Editor editor, PsiClass psiClassFromEditor, DataContext dataContext, boolean isBuilder, PsiClass classToGo) {
+        if (!isBuilder) {
+            displayPopup(editor, classToGo);
+        }
+    }
+
+    @Override
+    protected void doActionWhenClassToGoIsNotFound(Editor editor, PsiClass psiClassFromEditor, DataContext dataContext, boolean isBuilder) {
+        if (!isBuilder) {
+            displayChoosers.run(null);
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void displayPopup(Editor editor, PsiClass classToGo) {
+        JList popupList = popupListFactory.getPopupList();
+        popupDisplayer.displayPopupChooser(editor, popupList, () -> {
+            if (popupList.getSelectedValue() instanceof GoToBuilderAdditionalAction) {
+                psiHelper.navigateToClass(classToGo);
+            } else if (popupList.getSelectedValue() instanceof RegenerateBuilderAdditionalAction) {
+                displayChoosers.run(classToGo);
+            }
+        });
+    }
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/GoToBuilderActionHandler.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/GoToBuilderActionHandler.java
@@ -1,71 +1,37 @@
 package pl.mjedynak.idea.plugins.builder.action.handler;
 
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.actionSystem.DataKeys;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.actionSystem.EditorActionHandler;
-import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClass;
-import pl.mjedynak.idea.plugins.builder.factory.PopupListFactory;
+import pl.mjedynak.idea.plugins.builder.factory.GoToBuilderPopupListFactory;
 import pl.mjedynak.idea.plugins.builder.finder.BuilderFinder;
-import pl.mjedynak.idea.plugins.builder.gui.displayer.PopupDisplayer;
+import pl.mjedynak.idea.plugins.builder.gui.displayer.GoToBuilderPopupDisplayer;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 import pl.mjedynak.idea.plugins.builder.verifier.BuilderVerifier;
 
 import javax.swing.JList;
 
+public class GoToBuilderActionHandler extends AbstractBuilderActionHandler {
 
-public class GoToBuilderActionHandler extends EditorActionHandler {
-
-    private PsiHelper psiHelper;
-    private BuilderVerifier builderVerifier;
-    private BuilderFinder builderFinder;
-    private PopupDisplayer popupDisplayer;
-    private PopupListFactory popupListFactory;
-    private DisplayChoosersRunnable displayChoosersRunnable;
-
-    public GoToBuilderActionHandler(PsiHelper psiHelper, BuilderVerifier builderVerifier, BuilderFinder builderFinder, PopupDisplayer popupDisplayer,
-                                    PopupListFactory popupListFactory, DisplayChoosersRunnable displayChoosersRunnable) {
-        this.psiHelper = psiHelper;
-        this.builderVerifier = builderVerifier;
-        this.builderFinder = builderFinder;
-        this.popupDisplayer = popupDisplayer;
-        this.popupListFactory = popupListFactory;
-        this.displayChoosersRunnable = displayChoosersRunnable;
+    public GoToBuilderActionHandler(PsiHelper psiHelper, BuilderVerifier builderVerifier, BuilderFinder builderFinder, GoToBuilderPopupDisplayer popupDisplayer, GoToBuilderPopupListFactory popupListFactory, DisplayChoosers displayChoosersRunnable) {
+        super(psiHelper, builderVerifier, builderFinder, popupDisplayer, popupListFactory, displayChoosersRunnable);
     }
 
     @Override
-    public void execute(Editor editor, DataContext dataContext) {
-        Project project = (Project) dataContext.getData(DataKeys.PROJECT.getName());
-        PsiClass psiClassFromEditor = psiHelper.getPsiClassFromEditor(editor, project);
-        if (psiClassFromEditor != null) {
-            navigateOrDisplay(editor, psiClassFromEditor, dataContext);
+    protected void doActionWhenClassToGoIsFound(Editor editor, PsiClass psiClassFromEditor, DataContext dataContext, boolean isBuilder, PsiClass classToGo) {
+        psiHelper.navigateToClass(classToGo);
+    }
+
+    @Override
+    protected void doActionWhenClassToGoIsNotFound(Editor editor, PsiClass psiClassFromEditor, DataContext dataContext, boolean isBuilder) {
+        if (!isBuilder) {
+            displayPopup(editor);
         }
     }
 
-    private void navigateOrDisplay(Editor editor, PsiClass psiClassFromEditor, DataContext dataContext) {
-        boolean isBuilder = builderVerifier.isBuilder(psiClassFromEditor);
-        PsiClass classToGo = findClassToGo(psiClassFromEditor, isBuilder);
-        if (classToGo != null) {
-            psiHelper.navigateToClass(classToGo);
-        } else if (!isBuilder) {
-            displayPopup(editor, psiClassFromEditor, dataContext);
-        }
-    }
-
-    private void displayPopup(Editor editor, PsiClass psiClassFromEditor, DataContext dataContext) {
+    @SuppressWarnings("rawtypes")
+    private void displayPopup(Editor editor) {
         JList popupList = popupListFactory.getPopupList();
-        Project project = (Project) dataContext.getData(DataKeys.PROJECT.getName());
-        displayChoosersRunnable.setEditor(editor);
-        displayChoosersRunnable.setProject(project);
-        displayChoosersRunnable.setPsiClassFromEditor(psiClassFromEditor);
-        popupDisplayer.displayPopupChooser(editor, popupList, displayChoosersRunnable);
-    }
-
-    private PsiClass findClassToGo(PsiClass psiClassFromEditor, boolean isBuilder) {
-        if (isBuilder) {
-            return builderFinder.findClassForBuilder(psiClassFromEditor);
-        }
-        return builderFinder.findBuilderForClass(psiClassFromEditor);
+        popupDisplayer.displayPopupChooser(editor, popupList, () -> displayChoosers.run(null));
     }
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/factory/AbstractPopupListFactory.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/factory/AbstractPopupListFactory.java
@@ -1,23 +1,22 @@
 package pl.mjedynak.idea.plugins.builder.factory;
 
-import com.intellij.ui.components.JBList;
-import pl.mjedynak.idea.plugins.builder.action.GoToBuilderAdditionalAction;
 import pl.mjedynak.idea.plugins.builder.renderer.ActionCellRenderer;
 
 import javax.swing.JList;
 
-import static java.util.Arrays.asList;
-
-public class PopupListFactory {
+public abstract class AbstractPopupListFactory {
 
     private ActionCellRenderer actionCellRenderer;
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public JList getPopupList() {
-        JList list = new JBList(asList(new GoToBuilderAdditionalAction()));
+        JList list = createList();
         list.setCellRenderer(cellRenderer());
         return list;
     }
+
+    @SuppressWarnings("rawtypes")
+    protected abstract JList createList();
 
     private ActionCellRenderer cellRenderer() {
         if (actionCellRenderer == null) {

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/factory/CreateBuilderDialogFactory.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/factory/CreateBuilderDialogFactory.java
@@ -9,14 +9,13 @@ import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 
 public class CreateBuilderDialogFactory {
 
-    static final String BUILDER_SUFFIX = "Builder";
-    static final String METHOD_PREFIX = "with";
-
+    private static final String BUILDER_SUFFIX = "Builder";
+    private static final String METHOD_PREFIX = "with";
     private static final String DIALOG_NAME = "CreateBuilder";
+
     private PsiHelper psiHelper;
     private ReferenceEditorComboWithBrowseButtonFactory referenceEditorComboWithBrowseButtonFactory;
     private GuiHelper guiHelper;
-
 
     public CreateBuilderDialogFactory(PsiHelper psiHelper, ReferenceEditorComboWithBrowseButtonFactory referenceEditorComboWithBrowseButtonFactory, GuiHelper guiHelper) {
         this.psiHelper = psiHelper;
@@ -24,8 +23,8 @@ public class CreateBuilderDialogFactory {
         this.guiHelper = guiHelper;
     }
 
-    public CreateBuilderDialog createBuilderDialog(PsiClass sourceClass, Project project, PsiPackage srcPackage) {
+    public CreateBuilderDialog createBuilderDialog(PsiClass sourceClass, Project project, PsiPackage srcPackage, PsiClass existingBuilder) {
         return new CreateBuilderDialog(project, DIALOG_NAME, sourceClass, sourceClass.getName() + BUILDER_SUFFIX, METHOD_PREFIX, srcPackage, psiHelper, guiHelper,
-                referenceEditorComboWithBrowseButtonFactory);
+                referenceEditorComboWithBrowseButtonFactory, existingBuilder);
     }
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/factory/GenerateBuilderPopupListFactory.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/factory/GenerateBuilderPopupListFactory.java
@@ -1,0 +1,18 @@
+package pl.mjedynak.idea.plugins.builder.factory;
+
+import com.intellij.ui.components.JBList;
+import pl.mjedynak.idea.plugins.builder.action.GoToBuilderAdditionalAction;
+import pl.mjedynak.idea.plugins.builder.action.RegenerateBuilderAdditionalAction;
+
+import javax.swing.JList;
+
+import static java.util.Arrays.asList;
+
+public class GenerateBuilderPopupListFactory extends AbstractPopupListFactory {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected JList createList() {
+        return new JBList(asList(new GoToBuilderAdditionalAction(), new RegenerateBuilderAdditionalAction()));
+    }
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/factory/GoToBuilderPopupListFactory.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/factory/GoToBuilderPopupListFactory.java
@@ -1,0 +1,17 @@
+package pl.mjedynak.idea.plugins.builder.factory;
+
+import com.intellij.ui.components.JBList;
+import pl.mjedynak.idea.plugins.builder.action.GenerateBuilderAdditionalAction;
+
+import javax.swing.JList;
+
+import static java.util.Collections.singletonList;
+
+public class GoToBuilderPopupListFactory extends AbstractPopupListFactory {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected JList createList() {
+        return new JBList(singletonList(new GenerateBuilderAdditionalAction()));
+    }
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/gui/SelectDirectory.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/gui/SelectDirectory.java
@@ -1,48 +1,53 @@
 package pl.mjedynak.idea.plugins.builder.gui;
 
-import com.intellij.CommonBundle;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
+import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.util.IncorrectOperationException;
-import pl.mjedynak.idea.plugins.builder.gui.helper.GuiHelper;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 
 public class SelectDirectory implements Runnable {
 
     private CreateBuilderDialog createBuilderDialog;
     private PsiHelper psiHelper;
-    private GuiHelper guiHelper;
-    private Project project;
     private Module module;
     private String packageName;
     private String className;
+    private PsiClass existingBuilder;
 
-    public SelectDirectory(CreateBuilderDialog createBuilderDialog, PsiHelper psiHelper, GuiHelper guiHelper, Project project, Module module, String packageName, String className) {
+    public SelectDirectory(CreateBuilderDialog createBuilderDialog, PsiHelper psiHelper, Module module, String packageName, String className, PsiClass existingBuilder) {
         this.createBuilderDialog = createBuilderDialog;
         this.psiHelper = psiHelper;
-        this.guiHelper = guiHelper;
-        this.project = project;
         this.module = module;
         this.packageName = packageName;
         this.className = className;
+        this.existingBuilder = existingBuilder;
     }
 
     @Override
     public void run() {
-        String errorString = null;
-        try {
-            PsiDirectory targetDirectory = psiHelper.getDirectoryFromModuleAndPackageName(module, packageName);
-            if (targetDirectory != null) {
-                createBuilderDialog.setTargetDirectory(targetDirectory);
-                errorString = psiHelper.checkIfClassCanBeCreated(targetDirectory, className);
+        PsiDirectory targetDirectory = psiHelper.getDirectoryFromModuleAndPackageName(module, packageName);
+        if (targetDirectory != null) {
+            throwExceptionIfClassCannotBeCreated(targetDirectory);
+            createBuilderDialog.setTargetDirectory(targetDirectory);
+        }
+    }
+
+    private void throwExceptionIfClassCannotBeCreated(PsiDirectory targetDirectory) {
+        if (!isClassToCreateSameAsBuilderToDelete(targetDirectory)) {
+            String errorString = psiHelper.checkIfClassCanBeCreated(targetDirectory, className);
+            if (errorString != null) {
+                throw new IncorrectOperationException(errorString);
             }
-        } catch (IncorrectOperationException e) {
-            errorString = e.getMessage();
         }
-        if (errorString != null) {
-            guiHelper.showMessageDialog(project, errorString, CommonBundle.getErrorTitle(), Messages.getErrorIcon());
-        }
+    }
+
+    private boolean isClassToCreateSameAsBuilderToDelete(PsiDirectory targetDirectory) {
+        return existingBuilder != null
+                && existingBuilder.getContainingFile() != null
+                && existingBuilder.getContainingFile().getContainingDirectory() != null
+                && existingBuilder.getContainingFile().getContainingDirectory().getName().equals(targetDirectory.getName())
+                && existingBuilder.getName() != null
+                && existingBuilder.getName().equals(className);
     }
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/gui/displayer/AbstractPopupDisplayer.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/gui/displayer/AbstractPopupDisplayer.java
@@ -6,21 +6,22 @@ import pl.mjedynak.idea.plugins.builder.factory.PopupChooserBuilderFactory;
 
 import javax.swing.JList;
 
-public class PopupDisplayer {
-
-    static final String TITLE = "Builder not found";
+public abstract class AbstractPopupDisplayer {
 
     private PopupChooserBuilderFactory popupChooserBuilderFactory;
 
-    public PopupDisplayer(PopupChooserBuilderFactory popupChooserBuilderFactory) {
+    public AbstractPopupDisplayer(PopupChooserBuilderFactory popupChooserBuilderFactory) {
         this.popupChooserBuilderFactory = popupChooserBuilderFactory;
     }
 
+    @SuppressWarnings("rawtypes")
     public void displayPopupChooser(Editor editor, JList list, Runnable runnable) {
         PopupChooserBuilder builder = popupChooserBuilderFactory.getPopupChooserBuilder(list);
-        builder.setTitle(TITLE).
-                setItemChoosenCallback(runnable).
-                setMovable(true).
-                createPopup().showInBestPositionFor(editor);
+        builder.setTitle(getTitle()).
+            setItemChoosenCallback(runnable).
+            setMovable(true).
+            createPopup().showInBestPositionFor(editor);
     }
+
+    protected abstract String getTitle();
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/gui/displayer/GenerateBuilderPopupDisplayer.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/gui/displayer/GenerateBuilderPopupDisplayer.java
@@ -1,0 +1,17 @@
+package pl.mjedynak.idea.plugins.builder.gui.displayer;
+
+import pl.mjedynak.idea.plugins.builder.factory.PopupChooserBuilderFactory;
+
+public class GenerateBuilderPopupDisplayer extends AbstractPopupDisplayer {
+
+    private static final String TITLE = "Builder already exists";
+
+    public GenerateBuilderPopupDisplayer(PopupChooserBuilderFactory popupChooserBuilderFactory) {
+        super(popupChooserBuilderFactory);
+    }
+
+    @Override
+    protected String getTitle() {
+        return TITLE;
+    }
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/gui/displayer/GoToBuilderPopupDisplayer.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/gui/displayer/GoToBuilderPopupDisplayer.java
@@ -1,0 +1,17 @@
+package pl.mjedynak.idea.plugins.builder.gui.displayer;
+
+import pl.mjedynak.idea.plugins.builder.factory.PopupChooserBuilderFactory;
+
+public class GoToBuilderPopupDisplayer extends AbstractPopupDisplayer {
+
+    private static final String TITLE = "Builder not found";
+
+    public GoToBuilderPopupDisplayer(PopupChooserBuilderFactory popupChooserBuilderFactory) {
+        super(popupChooserBuilderFactory);
+    }
+
+    @Override
+    protected String getTitle() {
+        return TITLE;
+    }
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/renderer/ActionCellRenderer.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/renderer/ActionCellRenderer.java
@@ -9,7 +9,7 @@ import java.awt.Component;
 public class ActionCellRenderer extends DefaultListCellRenderer {
 
     @Override
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+    public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         Component result = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         if (value != null) {
             GotoTargetHandler.AdditionalAction action = (GotoTargetHandler.AdditionalAction) value;

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriter.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriter.java
@@ -1,6 +1,7 @@
 package pl.mjedynak.idea.plugins.builder.writer;
 
 import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.psi.PsiClass;
 import pl.mjedynak.idea.plugins.builder.psi.BuilderPsiClassBuilder;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 
@@ -15,8 +16,8 @@ public class BuilderWriter {
         this.psiHelper = psiHelper;
     }
 
-    public void writeBuilder(BuilderContext context) {
+    public void writeBuilder(BuilderContext context, PsiClass existingBuilder) {
         CommandProcessor commandProcessor = psiHelper.getCommandProcessor();
-        commandProcessor.executeCommand(context.getProject(), new BuilderWriterRunnable(builderPsiClassBuilder, context), CREATE_BUILDER_STRING, this);
+        commandProcessor.executeCommand(context.getProject(), new BuilderWriterRunnable(builderPsiClassBuilder, context, existingBuilder), CREATE_BUILDER_STRING, this);
     }
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterRunnable.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterRunnable.java
@@ -1,6 +1,7 @@
 package pl.mjedynak.idea.plugins.builder.writer;
 
 import com.intellij.openapi.application.Application;
+import com.intellij.psi.PsiClass;
 import pl.mjedynak.idea.plugins.builder.psi.BuilderPsiClassBuilder;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 
@@ -9,15 +10,17 @@ public class BuilderWriterRunnable implements Runnable {
     private PsiHelper psiHelper = new PsiHelper();
     private BuilderPsiClassBuilder builderPsiClassBuilder;
     private BuilderContext context;
+    private PsiClass existingBuilder;
 
-    public BuilderWriterRunnable(BuilderPsiClassBuilder builderPsiClassBuilder, BuilderContext context) {
+    public BuilderWriterRunnable(BuilderPsiClassBuilder builderPsiClassBuilder, BuilderContext context, PsiClass existingBuilder) {
         this.builderPsiClassBuilder = builderPsiClassBuilder;
         this.context = context;
+        this.existingBuilder = existingBuilder;
     }
 
     @Override
     public void run() {
         Application application = psiHelper.getApplication();
-        application.runWriteAction(new BuilderWriterComputable(builderPsiClassBuilder, context));
+        application.runWriteAction(new BuilderWriterComputable(builderPsiClassBuilder, context, existingBuilder));
     }
 }

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/action/GenerateBuilderAdditionalActionTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/action/GenerateBuilderAdditionalActionTest.java
@@ -8,16 +8,16 @@ import javax.swing.Icon;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GoToBuilderAdditionalActionTest {
+public class GenerateBuilderAdditionalActionTest {
 
-    private static final String TEXT = "Go to builder...";
+    private static final String TEXT = "Create New Builder...";
     private static final Icon ICON = IconLoader.getIcon("/actions/intentionBulb.png");
 
-    private GoToBuilderAdditionalAction action;
+    private GenerateBuilderAdditionalAction action;
 
     @Before
     public void setUp() {
-        action = new GoToBuilderAdditionalAction();
+        action = new GenerateBuilderAdditionalAction();
     }
 
     @Test

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/action/RegenerateBuilderAdditionalActionTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/action/RegenerateBuilderAdditionalActionTest.java
@@ -8,16 +8,16 @@ import javax.swing.Icon;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GoToBuilderAdditionalActionTest {
+public class RegenerateBuilderAdditionalActionTest {
 
-    private static final String TEXT = "Go to builder...";
+    private static final String TEXT = "Regenerate builder...";
     private static final Icon ICON = IconLoader.getIcon("/actions/intentionBulb.png");
 
-    private GoToBuilderAdditionalAction action;
+    private RegenerateBuilderAdditionalAction action;
 
     @Before
     public void setUp() {
-        action = new GoToBuilderAdditionalAction();
+        action = new RegenerateBuilderAdditionalAction();
     }
 
     @Test

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/factory/GoToBuilderPopupListFactoryTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/factory/GoToBuilderPopupListFactoryTest.java
@@ -10,9 +10,9 @@ import javax.swing.JList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 
-public class PopupListFactoryTest {
+public class GoToBuilderPopupListFactoryTest {
 
-    private PopupListFactory popupListFactory = new PopupListFactory();
+    private AbstractPopupListFactory popupListFactory = new GoToBuilderPopupListFactory();
 
     @Test
     public void shouldCreateJBListWithActionCellRenderer() {

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialogTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialogTest.java
@@ -1,17 +1,22 @@
 package pl.mjedynak.idea.plugins.builder.gui;
 
+import com.intellij.CommonBundle;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiDirectory;
-import com.intellij.psi.PsiManager;
 import com.intellij.psi.PsiPackage;
 import com.intellij.ui.ReferenceEditorComboWithBrowseButton;
+import com.intellij.util.IncorrectOperationException;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 import pl.mjedynak.idea.plugins.builder.factory.ReferenceEditorComboWithBrowseButtonFactory;
 import pl.mjedynak.idea.plugins.builder.gui.helper.GuiHelper;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
@@ -25,24 +30,29 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CreateBuilderDialogTest {
 
+    private static final String PACKAGE_NAME = "packageName";
+    private static final String ERROR_MESSAGE = "errorMessage";
+
     private CreateBuilderDialog createBuilderDialog;
 
     @Mock private Project project;
     @Mock private PsiPackage targetPackage;
-    @Mock private Module targetModule;
+    @Mock private Module module;
     @Mock private PsiHelper psiHelper;
     @Mock private GuiHelper guiHelper;
-    @Mock private PsiManager psiManager;
     @Mock private PsiClass sourceClass;
     @Mock private ReferenceEditorComboWithBrowseButtonFactory referenceEditorComboWithBrowseButtonFactory;
     @Mock private ReferenceEditorComboWithBrowseButton referenceEditorComboWithBrowseButton;
+    @Mock private PsiClass existingBuilder;
 
     private String className;
 
@@ -57,9 +67,8 @@ public class CreateBuilderDialogTest {
                 project, packageName, CreateBuilderDialog.RECENTS_KEY)).willReturn(referenceEditorComboWithBrowseButton);
 
         createBuilderDialog = new CreateBuilderDialog(
-                project, title, sourceClass, className, methodPrefix, targetPackage, psiHelper, guiHelper, referenceEditorComboWithBrowseButtonFactory);
+                project, title, sourceClass, className, methodPrefix, targetPackage, psiHelper, guiHelper, referenceEditorComboWithBrowseButtonFactory, existingBuilder);
     }
-
 
     @Test
     public void shouldReturnTargetClassNameFromValueGivenInConstructor() {
@@ -117,11 +126,10 @@ public class CreateBuilderDialogTest {
     public void shouldHandleClickingOK() {
         // given
         CreateBuilderDialog dialog = spy(createBuilderDialog);
-        String text = "text";
-        given(referenceEditorComboWithBrowseButton.getText()).willReturn(text);
-        given(psiHelper.findModuleForPsiClass(sourceClass, project)).willReturn(mock(Module.class));
+        given(referenceEditorComboWithBrowseButton.getText()).willReturn(PACKAGE_NAME);
+        given(psiHelper.findModuleForPsiClass(sourceClass, project)).willReturn(module);
         doReturn(false).when(dialog).isInnerBuilder();
-        doNothing().when(dialog).registerEntry(CreateBuilderDialog.RECENTS_KEY, text);
+        doNothing().when(dialog).registerEntry(CreateBuilderDialog.RECENTS_KEY, PACKAGE_NAME);
         doNothing().when(dialog).executeCommand(any(SelectDirectory.class));
         doNothing().when(dialog).callSuper();
 
@@ -129,19 +137,47 @@ public class CreateBuilderDialogTest {
         dialog.doOKAction();
 
         // then
-        verify(dialog).registerEntry(CreateBuilderDialog.RECENTS_KEY, text);
-        verify(dialog).executeCommand(any(SelectDirectory.class));
+        verify(dialog).registerEntry(CreateBuilderDialog.RECENTS_KEY, PACKAGE_NAME);
+        ArgumentCaptor<SelectDirectory> selectDirectoryArgumentCaptor = ArgumentCaptor.forClass(SelectDirectory.class);
+        verify(dialog).executeCommand(selectDirectoryArgumentCaptor.capture());
+        assertSelectDirectory(dialog, selectDirectoryArgumentCaptor.getValue());
         verify(dialog).callSuper();
+    }
+
+    @Test
+    public void shouldDisplayErrorMessageDialogIfClassCantBeCreatedWhenClickingOK() {
+        // given
+        CreateBuilderDialog dialog = spy(createBuilderDialog);
+        given(referenceEditorComboWithBrowseButton.getText()).willReturn(PACKAGE_NAME);
+        doNothing().when(dialog).registerEntry(CreateBuilderDialog.RECENTS_KEY, PACKAGE_NAME);
+        given(psiHelper.findModuleForPsiClass(sourceClass, project)).willReturn(module);
+        IncorrectOperationException exception = new IncorrectOperationException(ERROR_MESSAGE);
+        doThrow(exception).when(dialog).checkIfClassCanBeCreated(module);
+
+        // when
+        dialog.doOKAction();
+
+        // then
+        verify(guiHelper).showMessageDialog(project, ERROR_MESSAGE, CommonBundle.getErrorTitle(), Messages.getErrorIcon());
+        verify(dialog, never()).callSuper();
+    }
+
+    private void assertSelectDirectory(CreateBuilderDialog dialog, SelectDirectory selectDirectory) {
+        Assert.assertEquals(dialog, ReflectionTestUtils.getField(selectDirectory, "createBuilderDialog"));
+        Assert.assertEquals(psiHelper, ReflectionTestUtils.getField(selectDirectory, "psiHelper"));
+        Assert.assertEquals(module, ReflectionTestUtils.getField(selectDirectory, "module"));
+        Assert.assertEquals(PACKAGE_NAME, ReflectionTestUtils.getField(selectDirectory, "packageName"));
+        Assert.assertEquals(className, ReflectionTestUtils.getField(selectDirectory, "className"));
+        Assert.assertEquals(existingBuilder, ReflectionTestUtils.getField(selectDirectory, "existingBuilder"));
     }
 
     @Test(expected = IllegalStateException.class)
     public void shouldThrowIllegalStateExceptionWhenModuleNotFound() {
         // given
         CreateBuilderDialog dialog = spy(createBuilderDialog);
-        String text = "text";
-        given(referenceEditorComboWithBrowseButton.getText()).willReturn(text);
+        given(referenceEditorComboWithBrowseButton.getText()).willReturn(PACKAGE_NAME);
         given(psiHelper.findModuleForPsiClass(sourceClass, project)).willReturn(null);
-        doNothing().when(dialog).registerEntry(CreateBuilderDialog.RECENTS_KEY, text);
+        doNothing().when(dialog).registerEntry(CreateBuilderDialog.RECENTS_KEY, PACKAGE_NAME);
 
         // when
         dialog.doOKAction();

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/gui/SelectDirectoryTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/gui/SelectDirectoryTest.java
@@ -1,54 +1,56 @@
 package pl.mjedynak.idea.plugins.builder.gui;
 
-import com.intellij.CommonBundle;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
+import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiFile;
 import com.intellij.util.IncorrectOperationException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import pl.mjedynak.idea.plugins.builder.gui.helper.GuiHelper;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SelectDirectoryTest {
 
+    private static final String PACKAGE_NAME = "packageName";
+    private static final String CLASS_NAME = "className";
+    private static final String ERROR_MESSAGE = "errorMessage";
+    private static final String DIRECTORY_NAME = "directoryName";
+
     private SelectDirectory selectDirectory;
 
     @Mock private CreateBuilderDialog createBuilderDialog;
     @Mock private PsiHelper psiHelper;
-    @Mock private GuiHelper guiHelper;
-    @Mock private Project project;
     @Mock private Module module;
     @Mock private PsiDirectory targetDirectory;
+    @Mock private PsiClass existingBuilder;
 
-    private String packageName;
-    private String className;
-    private String errorMessage;
+    @SuppressWarnings("checkstyle:visibilitymodifier")
+    @Rule public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setUp() {
-        packageName = "packageName";
-        className = "className";
-        errorMessage = "errorMessage";
-
-        selectDirectory = new SelectDirectory(createBuilderDialog, psiHelper, guiHelper, project, module, packageName, className);
-
-        given(psiHelper.getDirectoryFromModuleAndPackageName(module, packageName)).willReturn(targetDirectory);
+        given(psiHelper.getDirectoryFromModuleAndPackageName(module, PACKAGE_NAME)).willReturn(targetDirectory);
     }
 
     @Test
     public void shouldDoNothingIfTargetDirectoryReturnedByPsiHelperIsNull() {
         // given
-        given(psiHelper.getDirectoryFromModuleAndPackageName(module, packageName)).willReturn(null);
+        selectDirectory = new SelectDirectory(createBuilderDialog, psiHelper, module, PACKAGE_NAME, CLASS_NAME, null);
+        given(psiHelper.getDirectoryFromModuleAndPackageName(module, PACKAGE_NAME)).willReturn(null);
 
         // when
         selectDirectory.run();
@@ -60,7 +62,8 @@ public class SelectDirectoryTest {
     @Test
     public void shouldSetTargetDirectoryOnCaller() {
         // given
-        given(psiHelper.checkIfClassCanBeCreated(targetDirectory, className)).willReturn(null);
+        selectDirectory = new SelectDirectory(createBuilderDialog, psiHelper, module, PACKAGE_NAME, CLASS_NAME, null);
+        given(psiHelper.checkIfClassCanBeCreated(targetDirectory, CLASS_NAME)).willReturn(null);
 
         // when
         selectDirectory.run();
@@ -69,29 +72,57 @@ public class SelectDirectoryTest {
         verify(createBuilderDialog).setTargetDirectory(targetDirectory);
     }
 
+    @SuppressWarnings("JUnitTestMethodWithNoAssertions")
     @Test
-    public void shouldDisplayErrorMessageWhenPsiHelperCheckReturnsErrorString() {
+    public void shouldThrowExceptionWhenPsiHelperCheckReturnsErrorString() {
+        // should throw
+        expectedException.expect(IncorrectOperationException.class);
+        expectedException.expectMessage(ERROR_MESSAGE);
+
         // given
-        given(psiHelper.checkIfClassCanBeCreated(targetDirectory, className)).willReturn(errorMessage);
+        selectDirectory = new SelectDirectory(createBuilderDialog, psiHelper, module, PACKAGE_NAME, CLASS_NAME, null);
+        given(psiHelper.checkIfClassCanBeCreated(targetDirectory, CLASS_NAME)).willReturn(ERROR_MESSAGE);
+
+        // when
+        selectDirectory.run();
+    }
+
+    @SuppressWarnings("JUnitTestMethodWithNoAssertions")
+    @Test
+    public void shouldThrowExceptionWhenPsiHelperThrowsIncorrectOperationException() {
+        // should throw
+        expectedException.expect(IncorrectOperationException.class);
+        expectedException.expectMessage(ERROR_MESSAGE);
+
+        // given
+        selectDirectory = new SelectDirectory(createBuilderDialog, psiHelper, module, PACKAGE_NAME, CLASS_NAME, null);
+        IncorrectOperationException exception = new IncorrectOperationException(ERROR_MESSAGE);
+        given(psiHelper.checkIfClassCanBeCreated(targetDirectory, CLASS_NAME)).willThrow(exception);
+
+        // when
+        selectDirectory.run();
+    }
+
+    @Test
+    public void shouldNotCheckIfClassCanBeCreatedIfExistingBuilderMustBeDeletedAndClassToCreateIsTheSame() {
+        // given
+        selectDirectory = new SelectDirectory(createBuilderDialog, psiHelper, module, PACKAGE_NAME, CLASS_NAME, existingBuilder);
+        mockIsClassToCreateSameAsBuilderToDelete();
 
         // when
         selectDirectory.run();
 
         // then
-        verify(guiHelper).showMessageDialog(project, errorMessage, CommonBundle.getErrorTitle(), Messages.getErrorIcon());
+        verify(psiHelper, never()).checkIfClassCanBeCreated(any(PsiDirectory.class), anyString());
     }
 
-    @Test
-    public void shouldDisplayErrorMessageWhenPsiHelperThrowsIncorrectOperationException() {
-        // given
-        IncorrectOperationException exception = new IncorrectOperationException(errorMessage);
-        given(psiHelper.checkIfClassCanBeCreated(targetDirectory, className)).willThrow(exception);
-
-        // when
-        selectDirectory.run();
-
-        // then
-        verify(guiHelper).showMessageDialog(project, errorMessage, CommonBundle.getErrorTitle(), Messages.getErrorIcon());
+    private void mockIsClassToCreateSameAsBuilderToDelete() {
+        PsiFile containingFile = mock(PsiFile.class);
+        PsiDirectory containingDirectory = mock(PsiDirectory.class);
+        given(existingBuilder.getContainingFile()).willReturn(containingFile);
+        given(containingFile.getContainingDirectory()).willReturn(containingDirectory);
+        given(containingDirectory.getName()).willReturn(DIRECTORY_NAME);
+        given(existingBuilder.getName()).willReturn(CLASS_NAME);
+        given(targetDirectory.getName()).willReturn(DIRECTORY_NAME);
     }
-
 }

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/gui/displayer/GenerateBuilderPopupDisplayerTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/gui/displayer/GenerateBuilderPopupDisplayerTest.java
@@ -1,0 +1,47 @@
+package pl.mjedynak.idea.plugins.builder.gui.displayer;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.ui.popup.JBPopup;
+import com.intellij.openapi.ui.popup.PopupChooserBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import pl.mjedynak.idea.plugins.builder.factory.PopupChooserBuilderFactory;
+
+import javax.swing.JList;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GenerateBuilderPopupDisplayerTest {
+
+    private static final String TITLE = "Builder already exists";
+
+    @InjectMocks private GenerateBuilderPopupDisplayer popupDisplayer;
+    @Mock private PopupChooserBuilderFactory popupChooserBuilderFactory;
+    @SuppressWarnings("rawtypes")
+    @Mock private JList list;
+    @Mock private PopupChooserBuilder popupChooserBuilder;
+    @Mock private Editor editor;
+    @Mock private Runnable runnable;
+    @Mock private JBPopup popup;
+
+    @Test
+    public void shouldInvokePopupChooserBuilder() {
+        // given
+        given(popupChooserBuilderFactory.getPopupChooserBuilder(list)).willReturn(popupChooserBuilder);
+        given(popupChooserBuilder.setTitle(TITLE)).willReturn(popupChooserBuilder);
+        given(popupChooserBuilder.setItemChoosenCallback(runnable)).willReturn(popupChooserBuilder);
+        given(popupChooserBuilder.setMovable(true)).willReturn(popupChooserBuilder);
+        given(popupChooserBuilder.createPopup()).willReturn(popup);
+
+        // when
+        popupDisplayer.displayPopupChooser(editor, list, runnable);
+
+        // then
+        verify(popup).showInBestPositionFor(editor);
+    }
+}

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/gui/displayer/GoToBuilderPopupDisplayerTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/gui/displayer/GoToBuilderPopupDisplayerTest.java
@@ -16,22 +16,24 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public class PopupDisplayerTest {
+public class GoToBuilderPopupDisplayerTest {
 
-    @InjectMocks private PopupDisplayer popupDisplayer;
+    private static final String TITLE = "Builder not found";
+
+    @InjectMocks private GoToBuilderPopupDisplayer popupDisplayer;
     @Mock private PopupChooserBuilderFactory popupChooserBuilderFactory;
+    @SuppressWarnings("rawtypes")
     @Mock private JList list;
     @Mock private PopupChooserBuilder popupChooserBuilder;
     @Mock private Editor editor;
     @Mock private Runnable runnable;
     @Mock private JBPopup popup;
 
-
     @Test
     public void shouldInvokePopupChooserBuilder() {
         // given
         given(popupChooserBuilderFactory.getPopupChooserBuilder(list)).willReturn(popupChooserBuilder);
-        given(popupChooserBuilder.setTitle(PopupDisplayer.TITLE)).willReturn(popupChooserBuilder);
+        given(popupChooserBuilder.setTitle(TITLE)).willReturn(popupChooserBuilder);
         given(popupChooserBuilder.setItemChoosenCallback(runnable)).willReturn(popupChooserBuilder);
         given(popupChooserBuilder.setMovable(true)).willReturn(popupChooserBuilder);
         given(popupChooserBuilder.createPopup()).willReturn(popup);

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputableTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputableTest.java
@@ -9,7 +9,6 @@ import com.intellij.util.IncorrectOperationException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import pl.mjedynak.idea.plugins.builder.gui.helper.GuiHelper;
@@ -23,11 +22,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
-
 @RunWith(MockitoJUnitRunner.class)
 public class BuilderWriterComputableTest {
 
-    @InjectMocks private BuilderWriterComputable builderWriterComputable;
+    private static final String METHOD_PREFIX = "with";
+
+    private BuilderWriterComputable builderWriterComputable;
 
     @Mock private PsiHelper psiHelper;
     @Mock private GuiHelper guiHelper;
@@ -38,12 +38,13 @@ public class BuilderWriterComputableTest {
     @Mock private PsiFile psiFile;
     @Mock private PsiElement psiElement;
     @Mock private BuilderContext context;
-    private String methodPrefix = "with";
+    @Mock private PsiClass existingBuilder;
 
     @Before
     public void setUp() {
+        builderWriterComputable = new BuilderWriterComputable(builderPsiClassBuilder, context, existingBuilder);
         given(context.getProject()).willReturn(project);
-        given(context.getMethodPrefix()).willReturn(methodPrefix);
+        given(context.getMethodPrefix()).willReturn(METHOD_PREFIX);
         given(context.isInner()).willReturn(false);
         setField(builderWriterComputable, "psiHelper", psiHelper);
         setField(builderWriterComputable, "guiHelper", guiHelper);
@@ -101,7 +102,7 @@ public class BuilderWriterComputableTest {
         given(builderPsiClassBuilder.withFields()).willReturn(builderPsiClassBuilder);
         given(builderPsiClassBuilder.withPrivateConstructor()).willReturn(builderPsiClassBuilder);
         given(builderPsiClassBuilder.withInitializingMethod()).willReturn(builderPsiClassBuilder);
-        given(builderPsiClassBuilder.withSetMethods(methodPrefix)).willReturn(builderPsiClassBuilder);
+        given(builderPsiClassBuilder.withSetMethods(METHOD_PREFIX)).willReturn(builderPsiClassBuilder);
         given(builderPsiClassBuilder.build()).willReturn(builderClass);
         given(builderClass.getContainingFile()).willReturn(psiFile);
         given(builderClass.getLBrace()).willReturn(psiElement);

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterRunnableTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterRunnableTest.java
@@ -1,18 +1,21 @@
 package pl.mjedynak.idea.plugins.builder.writer;
 
 import com.intellij.openapi.application.Application;
+import com.intellij.psi.PsiClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import pl.mjedynak.idea.plugins.builder.psi.BuilderPsiClassBuilder;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -23,10 +26,11 @@ public class BuilderWriterRunnableTest {
     @Mock private PsiHelper psiHelper;
     @Mock private BuilderPsiClassBuilder builderPsiClassBuilder;
     @Mock private BuilderContext context;
+    @Mock private PsiClass existingBuilder;
 
     @Before
     public void setUp() {
-        builderWriterRunnable = new BuilderWriterRunnable(builderPsiClassBuilder, context);
+        builderWriterRunnable = new BuilderWriterRunnable(builderPsiClassBuilder, context, existingBuilder);
         setField(builderWriterRunnable, "psiHelper", psiHelper);
     }
 
@@ -40,6 +44,10 @@ public class BuilderWriterRunnableTest {
         builderWriterRunnable.run();
 
         // then
-        verify(application).runWriteAction(any(BuilderWriterComputable.class));
+        ArgumentCaptor<BuilderWriterComputable> builderWriterComputableArgumentCaptor = ArgumentCaptor.forClass(BuilderWriterComputable.class);
+        verify(application).runWriteAction(builderWriterComputableArgumentCaptor.capture());
+        assertEquals(builderPsiClassBuilder, getField(builderWriterComputableArgumentCaptor.getValue(), "builderPsiClassBuilder"));
+        assertEquals(context, getField(builderWriterComputableArgumentCaptor.getValue(), "context"));
+        assertEquals(existingBuilder, getField(builderWriterComputableArgumentCaptor.getValue(), "existingBuilder"));
     }
 }

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterTest.java
@@ -2,19 +2,22 @@ package pl.mjedynak.idea.plugins.builder.writer;
 
 import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import pl.mjedynak.idea.plugins.builder.psi.BuilderPsiClassBuilder;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BuilderWriterTest {
@@ -24,6 +27,7 @@ public class BuilderWriterTest {
     @Mock private BuilderPsiClassBuilder builderPsiClassBuilder;
     @Mock private BuilderContext context;
     @Mock private Project project;
+    @Mock private PsiClass existingBuilder;
 
     @Test
     public void shouldExecuteCommandWithRunnable() {
@@ -33,9 +37,13 @@ public class BuilderWriterTest {
         given(context.getProject()).willReturn(project);
 
         // when
-        builderWriter.writeBuilder(context);
+        builderWriter.writeBuilder(context, existingBuilder);
 
         // then
-        verify(commandProcessor).executeCommand(eq(project), isA(BuilderWriterRunnable.class), eq(BuilderWriter.CREATE_BUILDER_STRING), eq(builderWriter));
+        ArgumentCaptor<BuilderWriterRunnable> builderWriterRunnableArgumentCaptor = ArgumentCaptor.forClass(BuilderWriterRunnable.class);
+        verify(commandProcessor).executeCommand(eq(project), builderWriterRunnableArgumentCaptor.capture(), eq(BuilderWriter.CREATE_BUILDER_STRING), eq(builderWriter));
+        assertEquals(builderPsiClassBuilder, getField(builderWriterRunnableArgumentCaptor.getValue(), "builderPsiClassBuilder"));
+        assertEquals(context, getField(builderWriterRunnableArgumentCaptor.getValue(), "context"));
+        assertEquals(existingBuilder, getField(builderWriterRunnableArgumentCaptor.getValue(), "existingBuilder"));
     }
 }


### PR DESCRIPTION
Adds the ability to regenerate an existing builder by deleting the previous builder and creating a new one

Previous behaviour (ALT+SHIFT+B) remains unchanged
Generation / regeneration is available from Code | Generate menu (this will address issue #20 as well)

The new feature can be described like this:
From a class to be built:
  - creates a builder if it does not exist
  - displays a popup if the builder already exists, allowing to go to builder or regenerate it
From a builder => do nothing

Other improvement :
Error message dialog when the fullname of the builder to be created already exists, has been moved from SelectDirectory to CreateBuilderDialog, in order to prevent display of MemberChooser if such a case happens

Checkstyle :
checkstyle.xml has been changed in order to:
  - allow protected fields for usage in abstract class
  - add specific SuppressWarnings (used in SelectDirectoryTest for usage of public modifier for @Rule ExpectedException)