### PR TITLE
BestContructorSelector to prevent generation of faulty constructor

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -20,64 +20,71 @@
           </ul>
         ]]>
     </description>
-    <version>1.1.6</version>
+    <version>1.1.7</version>
     <change-notes>
         <![CDATA[
+           version 1.1.7
+           <br/>
+           <ul>
+           <li>Added best constructor selection in order to prevent generation of faulty constructor in build() method</li>
+           <li>Fixed missorted parameters in constructor (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/35">issue #35</a>)</li>
+           <li>Fixed inline return statement when using constructor only in build() method (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/26">issue #26</a>)</li>
+           </ul>
            version 1.1.6
            <br/>
            <ul>
-           <li>Added ability to regenerate an existing builder, by automatically deleting the previous builder and creating a new one <a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/18">(issue #18)</a>
+           <li>Added ability to regenerate an existing builder, by automatically deleting the previous builder and creating a new one (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/18">issue #18</a>)
            (contribution by <a href="https://github.com/mkickax">mkickax</a>)</li>
-           <li>Builder Generator is now also available from <strong>Code | Generate</strong> menu <a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/20">(issue #20)</a>
+           <li>Builder Generator is now also available from <strong>Code | Generate</strong> menu (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/20">issue #20</a>)
            (contribution by <a href="https://github.com/mkickax">mkickax</a>)</li>
            </ul>
            version 1.1.5
            <br/>
            <ul>
            <li>Added ability to generate builder using a single field (the object to be built itself) instead of all fields of the object to be built
-           <a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/37">(issue #37)</a>
+           (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/37">issue #37</a>)
            (contribution by <a href="https://github.com/mkickax">mkickax</a>)</li>
            </li>
            </ul>
            version 1.1.4
            <br/>
            <ul>
-           <li>Ignore serialVersionUID field <a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/31">(issue #31)</a></li>
+           <li>Ignore serialVersionUID field (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/31">issue #31</a>)</li>
            </ul>
            version 1.1.3
            <br/>
            <ul>
-           <li>Fix incompatibility with IntelliJ 2017.1 <a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/33">(issue #33)</a></li>
+           <li>Fix incompatibility with IntelliJ 2017.1 (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/33">issue #33</a>)</li>
            </ul>
            version 1.1.2
            <br/>
            <ul>
-           <li>Inner builder is able to assign fields without constructor or setter <a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/11">(issue #11)</a>
+           <li>Inner builder is able to assign fields without constructor or setter (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/11">issue #11</a>)
            (contribution by <a href="https://github.com/blindpirate">blindpirate</a>)</li>
            </ul>
            version 1.1.1
            <br/>
            <ul>
-           <li>'but' method is now optional and disabled by default (issue #23)</li>
-           <li>Generated builder class is final (issue #24)</li>
+           <li>'but' method is now optional and disabled by default (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/23">issue #23</a>)</li>
+           <li>Generated builder class is final (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/24">issue #24</a>)</li>
            <li>Added possibility to find inner builder</li>
            </ul>
            version 1.1.0
            <br/>
            <ul>
-           <li>Added possibility to generate builder as inner class (issue #13)</li>
+           <li>Added possibility to generate builder as inner class (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/13">issue #13</a>)</li>
            </ul>
            version 1.0.11
            <br/>
            <ul>
-           <li>Added 'but' method generation (issue #10)</li>
-           <li>Fix for deadlock on startup (issue #12)</li>
-           <li>Fix for method name generation (issue #14)</li>
+           <li>Added 'but' method generation (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/10">issue #10</a>)</li>
+           <li>Fix for deadlock on startup (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/12">issue #12</a>)</li>
+           <li>Fix for method name generation (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/14">issue #14</a>)</li>
            </ul>
            version 1.0.10
            <br/>
            <ul>
-           <li>Support for Code Style field and parameter prefixes (issue #9)</li>
+           <li>Support for Code Style field and parameter prefixes (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/9">issue #9</a>)</li>
            </ul>
            version 1.0.9
            <br/>
@@ -87,13 +94,13 @@
            version 1.0.8
            <br/>
            <ul>
-           <li>Comments are no longer copied when creating builder(issue #5)</li>
-           <li>Compiled for Java 6 (issue #6)</li>
+           <li>Comments are no longer copied when creating builder (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/5">issue #5</a>)</li>
+           <li>Compiled for Java 6 (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/6">issue #6</a>)</li>
            </ul>
            version 1.0.7
            <br/>
            <ul>
-           <li>Attempt to fix a bug that caused deadlock during IDEA startup (issue #4)</li>
+           <li>Attempt to fix a bug that caused deadlock during IDEA startup (<a href="https://github.com/mjedynak/builder-generator-idea-plugin/issues/4">issue #4</a>)</li>
            </ul>
            version 1.0.6
            <br/>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -5,6 +5,7 @@
         "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
-    <suppress checks="MagicNumberCheck"
-              files="CreateBuilderDialog.java"/>
+    <suppress checks=".*" files="MemberChooser.java"/>
+    <suppress checks="MagicNumberCheck" files="CreateBuilderDialog.java"/>
+    <suppress checks="MagicNumberCheck" files=".*Test.java"/>
 </suppressions>

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/AbstractBuilderAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/AbstractBuilderAction.java
@@ -15,6 +15,7 @@ import pl.mjedynak.idea.plugins.builder.factory.ReferenceEditorComboWithBrowseBu
 import pl.mjedynak.idea.plugins.builder.finder.BuilderFinder;
 import pl.mjedynak.idea.plugins.builder.finder.ClassFinder;
 import pl.mjedynak.idea.plugins.builder.gui.helper.GuiHelper;
+import pl.mjedynak.idea.plugins.builder.psi.BestConstructorSelector;
 import pl.mjedynak.idea.plugins.builder.psi.BuilderPsiClassBuilder;
 import pl.mjedynak.idea.plugins.builder.psi.PsiFieldSelector;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
@@ -46,6 +47,7 @@ public abstract class AbstractBuilderAction extends EditorAction {
         picoContainer.registerComponentImplementation(PsiFieldSelector.class);
         picoContainer.registerComponentImplementation(PsiFieldsForBuilderFactory.class);
         picoContainer.registerComponentImplementation(DisplayChoosers.class);
+        picoContainer.registerComponentImplementation(BestConstructorSelector.class);
     }
 
     protected AbstractBuilderAction() {

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/factory/MemberChooser.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/factory/MemberChooser.java
@@ -1,4 +1,3 @@
-// CHECKSTYLE:OFF
 package pl.mjedynak.idea.plugins.builder.factory;
 
 import com.intellij.codeInsight.generation.*;
@@ -40,7 +39,6 @@ import java.awt.event.*;
 import java.util.*;
 import java.util.List;
 
-@SuppressWarnings("checkstyle")
 public class MemberChooser<T extends ClassMember> extends DialogWrapper implements TypeSafeDataProvider {
     private static final Logger LOG = Logger.getInstance("#com.intellij.ide.util.MemberChooser");
     protected Tree myTree;

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/factory/PsiFieldsForBuilderFactory.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/factory/PsiFieldsForBuilderFactory.java
@@ -1,38 +1,72 @@
 package pl.mjedynak.idea.plugins.builder.factory;
 
+import com.google.common.collect.Lists;
 import com.intellij.codeInsight.generation.PsiElementClassMember;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiMethod;
+import pl.mjedynak.idea.plugins.builder.psi.BestConstructorSelector;
 import pl.mjedynak.idea.plugins.builder.psi.model.PsiFieldsForBuilder;
 import pl.mjedynak.idea.plugins.builder.verifier.PsiFieldVerifier;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class PsiFieldsForBuilderFactory {
 
     private PsiFieldVerifier psiFieldVerifier;
+    private BestConstructorSelector bestConstructorSelector;
 
-    public PsiFieldsForBuilderFactory(PsiFieldVerifier psiFieldVerifier) {
+    public PsiFieldsForBuilderFactory(PsiFieldVerifier psiFieldVerifier, BestConstructorSelector bestConstructorSelector) {
         this.psiFieldVerifier = psiFieldVerifier;
+        this.bestConstructorSelector = bestConstructorSelector;
     }
 
+    @SuppressWarnings("rawtypes")
     public PsiFieldsForBuilder createPsiFieldsForBuilder(List<PsiElementClassMember> psiElementClassMembers, PsiClass psiClass) {
-        List<PsiField> psiFieldsForSetters = new ArrayList<PsiField>();
-        List<PsiField> psiFieldsForConstructor = new ArrayList<PsiField>();
-        List<PsiField> allSelectedPsiFields = new ArrayList<PsiField>();
+        List<PsiField> allSelectedPsiFields = Lists.newArrayList();
+        List<PsiField> psiFieldsFoundInSetters = Lists.newArrayList();
         for (PsiElementClassMember psiElementClassMember : psiElementClassMembers) {
             PsiElement psiElement = psiElementClassMember.getPsiElement();
             if (psiElement instanceof PsiField) {
                 allSelectedPsiFields.add((PsiField) psiElement);
                 if (psiFieldVerifier.isSetInSetterMethod((PsiField) psiElement, psiClass)) {
-                    psiFieldsForSetters.add((PsiField) psiElement);
-                } else if (psiFieldVerifier.isSetInConstructor((PsiField) psiElement, psiClass)) {
-                    psiFieldsForConstructor.add((PsiField) psiElement);
+                    psiFieldsFoundInSetters.add((PsiField) psiElement);
                 }
             }
         }
-        return new PsiFieldsForBuilder(psiFieldsForSetters, psiFieldsForConstructor, allSelectedPsiFields);
+        List<PsiField> psiFieldsToFindInConstructor = getSubList(allSelectedPsiFields, psiFieldsFoundInSetters);
+        List<PsiField> psiFieldsForConstructor = Lists.newArrayList();
+        PsiMethod bestConstructor = bestConstructorSelector.getBestConstructor(psiFieldsToFindInConstructor, psiClass);
+        if (bestConstructor != null) {
+            buildPsiFieldsForConstructor(psiFieldsForConstructor, allSelectedPsiFields, bestConstructor);
+        }
+        List<PsiField> psiFieldsForSetters = getSubList(psiFieldsFoundInSetters, psiFieldsForConstructor);
+
+        return new PsiFieldsForBuilder(psiFieldsForSetters, psiFieldsForConstructor, allSelectedPsiFields, bestConstructor);
+    }
+
+    private void buildPsiFieldsForConstructor(List<PsiField> psiFieldsForConstructor, List<PsiField> allSelectedPsiFields, PsiMethod bestConstructor) {
+        for (PsiField selectedPsiField : allSelectedPsiFields) {
+            if (psiFieldVerifier.checkConstructor(selectedPsiField, bestConstructor)) {
+                psiFieldsForConstructor.add(selectedPsiField);
+            }
+        }
+    }
+
+    private List<PsiField> getSubList(List<PsiField> inputList, List<PsiField> listToRemove) {
+        List<PsiField> newList = Lists.newArrayList();
+        for (PsiField inputPsiField : inputList) {
+            boolean setterMustBeAdded = true;
+            for (PsiField psiFieldToRemove : listToRemove) {
+                if (psiFieldToRemove.getName().equals(inputPsiField.getName())) {
+                    setterMustBeAdded = false;
+                }
+            }
+            if (setterMustBeAdded) {
+                newList.add(inputPsiField);
+            }
+        }
+        return newList;
     }
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/BestConstructorSelector.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/BestConstructorSelector.java
@@ -1,0 +1,130 @@
+package pl.mjedynak.idea.plugins.builder.psi;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiMethod;
+import org.jetbrains.annotations.NotNull;
+import pl.mjedynak.idea.plugins.builder.verifier.PsiFieldVerifier;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.TreeSet;
+
+public class BestConstructorSelector {
+
+    private PsiFieldVerifier psiFieldVerifier;
+
+    private List<ConstructorWithExtraData> constructorsWithEqualParameterCount;
+    private TreeSet<ConstructorWithExtraData> constructorsWithHigherParameterCount;
+    private List<ConstructorWithExtraData> constructorsWithLowerParameterCount;
+
+    public BestConstructorSelector(PsiFieldVerifier psiFieldVerifier) {
+        this.psiFieldVerifier = psiFieldVerifier;
+    }
+
+    public PsiMethod getBestConstructor(Collection<PsiField> psiFieldsToFindInConstructor, PsiClass psiClass) {
+        int fieldsToFindCount = psiFieldsToFindInConstructor.size();
+        createContructorLists(psiFieldsToFindInConstructor, psiClass);
+
+        computeNumberOfMatchingFields(constructorsWithEqualParameterCount, psiFieldsToFindInConstructor);
+        PsiMethod bestConstructor = findConstructorWithAllFieldsToFind(constructorsWithEqualParameterCount, fieldsToFindCount);
+        if (bestConstructor != null) {
+            return bestConstructor;
+        }
+
+        computeNumberOfMatchingFields(constructorsWithHigherParameterCount, psiFieldsToFindInConstructor);
+        bestConstructor = findConstructorWithAllFieldsToFind(constructorsWithHigherParameterCount, fieldsToFindCount);
+        if (bestConstructor != null) {
+            return bestConstructor;
+        }
+
+        computeNumberOfMatchingFields(constructorsWithLowerParameterCount, psiFieldsToFindInConstructor);
+        return findConstructorWithMaximumOfFieldsToFind();
+    }
+
+    private void createContructorLists(Collection<PsiField> psiFieldsToFindInConstructor, PsiClass psiClass) {
+        constructorsWithEqualParameterCount = Lists.newArrayList();
+        constructorsWithHigherParameterCount = Sets.newTreeSet();
+        constructorsWithLowerParameterCount = Lists.newArrayList();
+        PsiMethod[] constructors = psiClass.getConstructors();
+        for (PsiMethod constructor : constructors) {
+            int parameterCount = constructor.getParameterList().getParametersCount();
+            if (parameterCount > psiFieldsToFindInConstructor.size()) {
+                constructorsWithHigherParameterCount.add(new ConstructorWithExtraData(constructor));
+            } else if (parameterCount == psiFieldsToFindInConstructor.size()) {
+                constructorsWithEqualParameterCount.add(new ConstructorWithExtraData(constructor));
+            } else if (parameterCount >= 0) {
+                constructorsWithLowerParameterCount.add(new ConstructorWithExtraData(constructor));
+            }
+        }
+    }
+
+    private void computeNumberOfMatchingFields(Iterable<ConstructorWithExtraData> constuctorsWithExtraData, Iterable<PsiField> psiFieldsToFindInConstructor) {
+        for (ConstructorWithExtraData constructorWithExtraData : constuctorsWithExtraData) {
+            int matchingFieldsCount = 0;
+            for (PsiField psiField : psiFieldsToFindInConstructor) {
+                if (psiFieldVerifier.checkConstructor(psiField, constructorWithExtraData.getConstructor())) {
+                    matchingFieldsCount++;
+                }
+            }
+            constructorWithExtraData.setMatchingFieldsCount(matchingFieldsCount);
+        }
+    }
+
+    private PsiMethod findConstructorWithAllFieldsToFind(Iterable<ConstructorWithExtraData> constructorsWithExtraData, int fieldsToFindCount) {
+        for (ConstructorWithExtraData constructorWithExtraData : constructorsWithExtraData) {
+            if (constructorWithExtraData.getMatchingFieldsCount() == fieldsToFindCount) {
+                return constructorWithExtraData.getConstructor();
+            }
+        }
+        return null;
+    }
+
+    private PsiMethod findConstructorWithMaximumOfFieldsToFind() {
+        Iterable<ConstructorWithExtraData> allContructors = Iterables.concat(constructorsWithEqualParameterCount, constructorsWithHigherParameterCount, constructorsWithLowerParameterCount);
+        int matchingFieldCount = -1;
+        int parameterCount = 0;
+        PsiMethod bestConstructor = null;
+        for (ConstructorWithExtraData constructor : allContructors) {
+            if (constructor.getMatchingFieldsCount() > matchingFieldCount || constructor.getMatchingFieldsCount() == matchingFieldCount && constructor.getParametersCount() < parameterCount) {
+                bestConstructor = constructor.getConstructor();
+                matchingFieldCount = constructor.getMatchingFieldsCount();
+                parameterCount = constructor.getParametersCount();
+            }
+        }
+        return bestConstructor;
+    }
+
+    private class ConstructorWithExtraData implements Comparable<ConstructorWithExtraData> {
+        private PsiMethod constructor;
+        private Integer matchingFieldsCount;
+
+        ConstructorWithExtraData(PsiMethod constructor) {
+            this.constructor = constructor;
+        }
+
+        @Override
+        public int compareTo(@NotNull ConstructorWithExtraData constructorToCompare) {
+            return this.getParametersCount().compareTo(constructorToCompare.getParametersCount());
+        }
+
+        PsiMethod getConstructor() {
+            return constructor;
+        }
+
+        Integer getMatchingFieldsCount() {
+            return matchingFieldsCount;
+        }
+
+        void setMatchingFieldsCount(Integer matchingFieldsCount) {
+            this.matchingFieldsCount = matchingFieldsCount;
+        }
+
+        Integer getParametersCount() {
+            return constructor == null ? null : constructor.getParameterList().getParametersCount();
+        }
+    }
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/model/PsiFieldsForBuilder.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/model/PsiFieldsForBuilder.java
@@ -2,6 +2,7 @@ package pl.mjedynak.idea.plugins.builder.psi.model;
 
 import com.google.common.collect.ImmutableList;
 import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiMethod;
 
 import java.util.List;
 
@@ -10,11 +11,13 @@ public class PsiFieldsForBuilder {
     private List<PsiField> psiFieldsForSetters;
     private List<PsiField> psiFieldsForConstructor;
     private List<PsiField> allSelectedPsiFields;
+    private final PsiMethod bestContructor;
 
-    public PsiFieldsForBuilder(List<PsiField> psiFieldsForSetters, List<PsiField> psiFieldsForConstructor, List<PsiField> allSelectedPsiFields) {
+    public PsiFieldsForBuilder(List<PsiField> psiFieldsForSetters, List<PsiField> psiFieldsForConstructor, List<PsiField> allSelectedPsiFields, PsiMethod bestConstructor) {
         this.psiFieldsForSetters = ImmutableList.copyOf(psiFieldsForSetters);
         this.psiFieldsForConstructor = ImmutableList.copyOf(psiFieldsForConstructor);
         this.allSelectedPsiFields = ImmutableList.copyOf(allSelectedPsiFields);
+        this.bestContructor = bestConstructor;
     }
 
     public List<PsiField> getFieldsForSetters() {
@@ -27,5 +30,9 @@ public class PsiFieldsForBuilder {
 
     public List<PsiField> getAllSelectedFields() {
         return allSelectedPsiFields;
+    }
+
+    public PsiMethod getBestContructor() {
+        return bestContructor;
     }
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/verifier/PsiFieldVerifier.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/verifier/PsiFieldVerifier.java
@@ -28,7 +28,7 @@ public class PsiFieldVerifier {
         return result;
     }
 
-    private boolean checkConstructor(PsiField psiField, PsiMethod constructor) {
+    public boolean checkConstructor(PsiField psiField, PsiMethod constructor) {
         PsiParameterList parameterList = constructor.getParameterList();
         PsiParameter[] parameters = parameterList.getParameters();
         return iterateOverParameters(psiField, parameters);
@@ -50,7 +50,7 @@ public class PsiFieldVerifier {
         return result;
     }
 
-    private boolean areNameAndTypeEqual(PsiField psiField, PsiParameter parameter) {
+    public boolean areNameAndTypeEqual(PsiField psiField, PsiParameter parameter) {
         String parameterNamePrefix = codeStyleSettings.getParameterNamePrefix();
         String parameterName = parameter.getName();
         String parameterNameWithoutPrefix = parameterName.replace(parameterNamePrefix, "");

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosersTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosersTest.java
@@ -1,5 +1,6 @@
 package pl.mjedynak.idea.plugins.builder.action.handler;
 
+import com.google.common.collect.Lists;
 import com.intellij.codeInsight.generation.PsiElementClassMember;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
@@ -9,7 +10,6 @@ import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.PsiPackage;
-import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/factory/PsiFieldsForBuilderFactoryTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/factory/PsiFieldsForBuilderFactoryTest.java
@@ -1,118 +1,175 @@
 package pl.mjedynak.idea.plugins.builder.factory;
 
+import com.google.common.collect.Lists;
 import com.intellij.codeInsight.generation.PsiElementClassMember;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiField;
-import org.junit.Before;
+import com.intellij.psi.PsiMethod;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import pl.mjedynak.idea.plugins.builder.psi.BestConstructorSelector;
 import pl.mjedynak.idea.plugins.builder.psi.model.PsiFieldsForBuilder;
 import pl.mjedynak.idea.plugins.builder.verifier.PsiFieldVerifier;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PsiFieldsForBuilderFactoryTest {
 
+    private static final String PSI_FIELD_NAME = "psiFieldName";
+    private static final String PSI_FIELD_NAME_IN_SETTER_ONLY = "psiFieldNameInSetterOnly";
+    private static final String PSI_FIELD_NAME_IN_CONSTRUCTOR_ONLY = "psiFieldNameInConstructorOnly";
+    private static final String PSI_FIELD_NAME_IN_SETTER_AND_CONSTRUCTOR = "psiFieldNameInSetterAndConstructor";
+    private static final String PSI_FIELD_NAME_NOWHERE = "psiFieldNameNowhere";
+
     @InjectMocks private PsiFieldsForBuilderFactory factory;
     @Mock private PsiFieldVerifier psiFieldVerifier;
     @Mock private PsiClass psiClass;
+    @SuppressWarnings("rawtypes")
     @Mock private PsiElementClassMember psiElementClassMember;
+    @SuppressWarnings("rawtypes")
+    @Mock private PsiElementClassMember psiElementClassMemberInSetterOnly;
+    @SuppressWarnings("rawtypes")
+    @Mock private PsiElementClassMember psiElementClassMemberInConstructorOnly;
+    @SuppressWarnings("rawtypes")
+    @Mock private PsiElementClassMember psiElementClassMemberInSetterAndConstructor;
+    @SuppressWarnings("rawtypes")
+    @Mock private PsiElementClassMember psiElementClassMemberNowhere;
+    @Mock private PsiField psiField;
+    @Mock private PsiField psiFieldInSetterOnly;
+    @Mock private PsiField psiFieldInConstructorOnly;
+    @Mock private PsiField psiFieldInSetterAndConstructor;
+    @Mock private PsiField psiFieldNowhere;
+    @Mock private BestConstructorSelector bestConstructorSelector;
+    @Mock private PsiMethod bestConstructor;
 
+    @Captor private ArgumentCaptor<List<PsiField>> argumentCaptor;
+
+    @SuppressWarnings("rawtypes")
     private List<PsiElementClassMember> psiElementClassMembers;
 
-    @Mock private PsiField psiField;
-
-    @Before
-    public void setUp() {
-        psiElementClassMembers = Arrays.asList(psiElementClassMember);
+    private void initCommonMock() {
+        psiElementClassMembers = Lists.newArrayList(psiElementClassMember);
         given(psiElementClassMember.getPsiElement()).willReturn(psiField);
+        given(psiField.getName()).willReturn(PSI_FIELD_NAME);
     }
 
     @Test
     public void shouldCreateObjectWithPsiFieldsForSetters() {
         // given
+        initCommonMock();
         given(psiFieldVerifier.isSetInSetterMethod(psiField, psiClass)).willReturn(true);
+        given(bestConstructorSelector.getBestConstructor(anyListOf(PsiField.class), eq(psiClass))).willReturn(bestConstructor);
+        given(psiFieldVerifier.checkConstructor(psiField, bestConstructor)).willReturn(false);
 
         // when
         PsiFieldsForBuilder result = factory.createPsiFieldsForBuilder(psiElementClassMembers, psiClass);
 
         // then
         assertThat(result).isNotNull();
-        assertThatFieldsForConstructorAreEmpty(result);
+        assertThat(result.getFieldsForConstructor()).isNotNull().hasSize(0);
+        assertThat(result.getFieldsForSetters()).isNotNull().hasSize(1).containsOnly(psiField);
 
-        List<PsiField> fieldsForSetters = result.getFieldsForSetters();
-        assertThat(fieldsForSetters).isNotNull();
-        assertThat(fieldsForSetters).hasSize(1);
-        assertThat(fieldsForSetters.get(0)).isEqualTo(psiField);
+        verify(psiFieldVerifier).isSetInSetterMethod(psiField, psiClass);
+        verify(bestConstructorSelector).getBestConstructor(argumentCaptor.capture(), eq(psiClass));
+        assertThat(argumentCaptor.getValue()).isNotNull().hasSize(0);
+        verify(psiFieldVerifier).checkConstructor(psiField, bestConstructor);
     }
 
     @Test
     public void shouldCreateObjectWithPsiFieldsForConstructor() {
         // given
-        given(psiFieldVerifier.isSetInConstructor(psiField, psiClass)).willReturn(true);
+        initCommonMock();
+        given(psiFieldVerifier.isSetInSetterMethod(psiField, psiClass)).willReturn(false);
+        given(bestConstructorSelector.getBestConstructor(anyListOf(PsiField.class), eq(psiClass))).willReturn(bestConstructor);
+        given(psiFieldVerifier.checkConstructor(psiField, bestConstructor)).willReturn(true);
 
         // when
         PsiFieldsForBuilder result = factory.createPsiFieldsForBuilder(psiElementClassMembers, psiClass);
 
         // then
         assertThat(result).isNotNull();
-        assertThatFieldsForSettersAreEmpty(result);
+        assertThat(result.getFieldsForSetters()).isNotNull().hasSize(0);
+        assertThat(result.getFieldsForConstructor()).isNotNull().hasSize(1).containsOnly(psiField);
 
-        List<PsiField> fieldsForConstructor = result.getFieldsForConstructor();
-        assertThat(fieldsForConstructor).isNotNull();
-        assertThat(fieldsForConstructor).hasSize(1);
-        assertThat(fieldsForConstructor.get(0)).isEqualTo(psiField);
+        verify(psiFieldVerifier).isSetInSetterMethod(psiField, psiClass);
+        verify(bestConstructorSelector).getBestConstructor(argumentCaptor.capture(), eq(psiClass));
+        assertThat(argumentCaptor.getValue()).isNotNull().hasSize(1).extracting("name").containsOnly(PSI_FIELD_NAME);
+        verify(psiFieldVerifier).checkConstructor(psiField, bestConstructor);
     }
 
     @Test
     public void shouldCreateObjectWithEmptyList() {
+        // given
+        initCommonMock();
+        given(psiFieldVerifier.isSetInSetterMethod(psiField, psiClass)).willReturn(false);
+        given(bestConstructorSelector.getBestConstructor(anyListOf(PsiField.class), eq(psiClass))).willReturn(bestConstructor);
+        given(psiFieldVerifier.checkConstructor(psiField, bestConstructor)).willReturn(false);
+
         // when
         PsiFieldsForBuilder result = factory.createPsiFieldsForBuilder(psiElementClassMembers, psiClass);
 
         // then
         assertThat(result).isNotNull();
-        assertThatFieldsForSettersAreEmpty(result);
-        assertThatFieldsForConstructorAreEmpty(result);
+        assertThat(result.getFieldsForSetters()).isNotNull().hasSize(0);
+        assertThat(result.getFieldsForConstructor()).isNotNull().hasSize(0);
+
+        verify(psiFieldVerifier).isSetInSetterMethod(psiField, psiClass);
+        verify(bestConstructorSelector).getBestConstructor(argumentCaptor.capture(), eq(psiClass));
+        assertThat(argumentCaptor.getValue()).isNotNull().hasSize(1).extracting("name").containsOnly(PSI_FIELD_NAME);
+        verify(psiFieldVerifier).checkConstructor(psiField, bestConstructor);
     }
 
     @Test
-    public void shouldPreferFieldsForSetterOverFieldsForConstructor() {
+    public void shouldManageTrickyCaseAccordingToBestConstructorSelection() {
         // given
-        given(psiFieldVerifier.isSetInConstructor(psiField, psiClass)).willReturn(true);
-        given(psiFieldVerifier.isSetInSetterMethod(psiField, psiClass)).willReturn(true);
+        psiElementClassMembers = Lists.newArrayList(psiElementClassMemberInSetterOnly, psiElementClassMemberInConstructorOnly,
+                psiElementClassMemberInSetterAndConstructor, psiElementClassMemberNowhere);
+
+        given(psiElementClassMemberInSetterOnly.getPsiElement()).willReturn(psiFieldInSetterOnly);
+        given(psiElementClassMemberInConstructorOnly.getPsiElement()).willReturn(psiFieldInConstructorOnly);
+        given(psiElementClassMemberInSetterAndConstructor.getPsiElement()).willReturn(psiFieldInSetterAndConstructor);
+        given(psiElementClassMemberNowhere.getPsiElement()).willReturn(psiFieldNowhere);
+
+        given(psiFieldInSetterOnly.getName()).willReturn(PSI_FIELD_NAME_IN_SETTER_ONLY);
+        given(psiFieldInConstructorOnly.getName()).willReturn(PSI_FIELD_NAME_IN_CONSTRUCTOR_ONLY);
+        given(psiFieldInSetterAndConstructor.getName()).willReturn(PSI_FIELD_NAME_IN_SETTER_AND_CONSTRUCTOR);
+        given(psiFieldNowhere.getName()).willReturn(PSI_FIELD_NAME_NOWHERE);
+
+        given(psiFieldVerifier.isSetInSetterMethod(psiFieldInSetterOnly, psiClass)).willReturn(true);
+        given(psiFieldVerifier.isSetInSetterMethod(psiFieldInConstructorOnly, psiClass)).willReturn(false);
+        given(psiFieldVerifier.isSetInSetterMethod(psiFieldInSetterAndConstructor, psiClass)).willReturn(true);
+        given(psiFieldVerifier.isSetInSetterMethod(psiFieldNowhere, psiClass)).willReturn(false);
+
+        given(bestConstructorSelector.getBestConstructor(anyListOf(PsiField.class), eq(psiClass))).willReturn(bestConstructor);
+
+        given(psiFieldVerifier.checkConstructor(psiFieldInSetterOnly, bestConstructor)).willReturn(false);
+        given(psiFieldVerifier.checkConstructor(psiFieldInConstructorOnly, bestConstructor)).willReturn(true);
+        given(psiFieldVerifier.checkConstructor(psiFieldInSetterAndConstructor, bestConstructor)).willReturn(true);
+        given(psiFieldVerifier.checkConstructor(psiFieldNowhere, bestConstructor)).willReturn(false);
 
         // when
         PsiFieldsForBuilder result = factory.createPsiFieldsForBuilder(psiElementClassMembers, psiClass);
 
         // then
         assertThat(result).isNotNull();
-        assertThatFieldsForConstructorAreEmpty(result);
-
-        List<PsiField> fieldsForSetters = result.getFieldsForSetters();
-        assertThat(fieldsForSetters).isNotNull();
-        assertThat(fieldsForSetters).hasSize(1);
-        assertThat(fieldsForSetters.get(0)).isEqualTo(psiField);
-
+        assertThat(result.getAllSelectedFields()).isNotNull().hasSize(4)
+                .containsOnly(psiFieldInSetterOnly, psiFieldInConstructorOnly, psiFieldInSetterAndConstructor, psiFieldNowhere);
+        assertThat(result.getFieldsForConstructor()).isNotNull().hasSize(2)
+                .containsOnly(psiFieldInConstructorOnly, psiFieldInSetterAndConstructor);
+        assertThat(result.getFieldsForSetters()).isNotNull().hasSize(1)
+                .containsOnly(psiFieldInSetterOnly);
+        assertThat(result.getBestContructor()).isEqualTo(bestConstructor);
     }
-
-    private void assertThatFieldsForConstructorAreEmpty(PsiFieldsForBuilder result) {
-        List<PsiField> fieldsForConstructor = result.getFieldsForConstructor();
-        assertThat(fieldsForConstructor).isNotNull();
-        assertThat(fieldsForConstructor).hasSize(0);
-    }
-
-    private void assertThatFieldsForSettersAreEmpty(PsiFieldsForBuilder result) {
-        List<PsiField> fieldsForSetters = result.getFieldsForSetters();
-        assertThat(fieldsForSetters).isNotNull();
-        assertThat(fieldsForSetters).hasSize(0);
-    }
-
 }

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/finder/BestConstructorSelectorTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/finder/BestConstructorSelectorTest.java
@@ -1,0 +1,154 @@
+package pl.mjedynak.idea.plugins.builder.finder;
+
+import com.google.common.collect.Lists;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiParameter;
+import com.intellij.psi.PsiParameterList;
+import com.intellij.psi.PsiParameterListOwner;
+import com.intellij.psi.PsiPrimitiveType;
+import com.intellij.psi.PsiType;
+import com.intellij.psi.PsiVariable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import pl.mjedynak.idea.plugins.builder.psi.BestConstructorSelector;
+import pl.mjedynak.idea.plugins.builder.settings.CodeStyleSettings;
+import pl.mjedynak.idea.plugins.builder.verifier.PsiFieldVerifier;
+
+import java.util.Collection;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BestConstructorSelectorTest {
+
+    private static final String NAME_1 = "name1";
+    private static final String NAME_2 = "name2";
+    private static final String NAME_3 = "name3";
+    private static final String NAME_4 = "name4";
+    private static final String NAME_5 = "name5";
+    private static final PsiParameter[] EMPTY_PSI_PARAMETERS = new PsiParameter[0];
+
+    @Mock private CodeStyleSettings settings;
+    @Mock private PsiClass psiClass;
+    @Mock private PsiMethod constructor0;
+    @Mock private PsiMethod constructor1;
+    @Mock private PsiMethod constructor2a;
+    @Mock private PsiMethod constructor2b;
+    @Mock private PsiMethod constructor3;
+    @Mock private PsiParameterList parameterList0;
+    @Mock private PsiParameterList parameterList1;
+    @Mock private PsiParameterList parameterList2a;
+    @Mock private PsiParameterList parameterList2b;
+    @Mock private PsiParameterList parameterList3;
+    @Mock private PsiField psiField1;
+    @Mock private PsiField psiField2;
+    @Mock private PsiField psiField3;
+    @Mock private PsiField psiField4;
+    @Mock private PsiField psiField5;
+    @Mock private PsiParameter psiParameter1;
+    @Mock private PsiParameter psiParameter2;
+    @Mock private PsiParameter psiParameter3;
+    @Mock private PsiParameter psiParameter4;
+
+    private PsiFieldVerifier verifier = new PsiFieldVerifier();
+    private BestConstructorSelector finder = new BestConstructorSelector(verifier);
+
+    @Before
+    public void initMock() {
+        setField(verifier, "codeStyleSettings", settings);
+        given(settings.getParameterNamePrefix()).willReturn(EMPTY);
+        given(settings.getFieldNamePrefix()).willReturn(EMPTY);
+
+        mockPsiVariable(psiField1, NAME_1, PsiType.INT);
+        mockPsiVariable(psiField2, NAME_2, PsiType.INT);
+        mockPsiVariable(psiField3, NAME_3, PsiType.INT);
+        mockPsiVariable(psiField4, NAME_4, PsiType.INT);
+        mockPsiVariable(psiField5, NAME_5, PsiType.INT);
+
+        mockPsiVariable(psiParameter1, NAME_1, PsiType.INT);
+        mockPsiVariable(psiParameter2, NAME_2, PsiType.INT);
+        mockPsiVariable(psiParameter3, NAME_3, PsiType.INT);
+        mockPsiVariable(psiParameter4, NAME_4, PsiType.INT);
+
+        mockContructor(constructor0, parameterList0, EMPTY_PSI_PARAMETERS);
+        mockContructor(constructor1, parameterList1, psiParameter4);
+        mockContructor(constructor2a, parameterList2a, psiParameter1, psiParameter2);
+        mockContructor(constructor2b, parameterList2b, psiParameter1, psiParameter4);
+        mockContructor(constructor3, parameterList3, psiParameter1, psiParameter2, psiParameter3);
+    }
+
+    private void mockPsiVariable(PsiVariable psiVariable, String name, PsiPrimitiveType type) {
+        given(psiVariable.getName()).willReturn(name);
+        given(psiVariable.getType()).willReturn(type);
+    }
+
+    private void mockContructor(PsiParameterListOwner constructor, PsiParameterList parameterList, PsiParameter... psiParameters) {
+        given(constructor.getParameterList()).willReturn(parameterList);
+        given(parameterList.getParameters()).willReturn(psiParameters);
+        given(parameterList.getParametersCount()).willReturn(psiParameters.length);
+    }
+
+    @Test
+    public void shouldFindConstructorWithLeastParametersIfAnyFieldsToFind() {
+        doTest(
+                Lists.newArrayList(),
+                new PsiMethod[]{constructor0, constructor1, constructor2a, constructor2b, constructor3},
+                constructor0
+        );
+    }
+
+    @Test
+    public void shouldFindConstructorWithLeastParametersIfAnyFieldsToFindFoundInConstructors() {
+        doTest(
+                Lists.newArrayList(psiField5),
+                new PsiMethod[]{constructor0, constructor1, constructor2a, constructor2b, constructor3},
+                constructor0
+        );
+    }
+
+    @Test
+    public void shouldFindConstructorWithExactMatching() {
+        doTest(
+                Lists.newArrayList(psiField1, psiField2),
+                new PsiMethod[]{constructor0, constructor1, constructor2a, constructor2b, constructor3},
+                constructor2a
+        );
+    }
+
+    @Test
+    public void shouldFindConstructorWithAllFieldsFoundButExtraParameters() {
+        doTest(
+                Lists.newArrayList(psiField2, psiField3),
+                new PsiMethod[]{constructor0, constructor1, constructor2a, constructor2b, constructor3},
+                constructor3
+        );
+    }
+
+    @Test
+    public void shouldFindConstructorWithMaxFieldsFoundAndLessParameters() {
+        doTest(
+                Lists.newArrayList(psiField2, psiField4),
+                new PsiMethod[]{constructor0, constructor1, constructor2a, constructor2b, constructor3},
+                constructor1
+        );
+    }
+
+    private void doTest(Collection<PsiField> psiFields, PsiMethod[] psiMethods, PsiMethod expectedConstructor) {
+        // given
+        given(psiClass.getConstructors()).willReturn(psiMethods);
+
+        // when
+        PsiMethod bestConstructor = finder.getBestConstructor(psiFields, psiClass);
+
+        // then
+        assertThat(bestConstructor).isEqualTo(expectedConstructor);
+    }
+}

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/psi/model/PsiFieldsForBuilderTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/psi/model/PsiFieldsForBuilderTest.java
@@ -1,12 +1,13 @@
 package pl.mjedynak.idea.plugins.builder.psi.model;
 
+import com.google.common.collect.Lists;
 import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiMethod;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,24 +21,27 @@ public class PsiFieldsForBuilderTest {
     private List<PsiField> psiFieldsForSetters;
     private List<PsiField> psiFieldsForConstructor;
     private List<PsiField> allSelectedPsiFields;
+    private PsiMethod bestConstructor;
 
     @Before
     public void setUp() {
-        psiFieldsForSetters = new ArrayList<PsiField>();
+        psiFieldsForSetters = Lists.newArrayList();
         psiFieldsForSetters.add(mock(PsiField.class));
-        psiFieldsForConstructor = new ArrayList<PsiField>();
+        psiFieldsForConstructor = Lists.newArrayList();
         psiFieldsForConstructor.add(mock(PsiField.class));
-        allSelectedPsiFields = new ArrayList<PsiField>();
+        allSelectedPsiFields = Lists.newArrayList();
         allSelectedPsiFields.add(mock(PsiField.class));
         allSelectedPsiFields.add(mock(PsiField.class));
-        psiFieldsForBuilder = new PsiFieldsForBuilder(psiFieldsForSetters, psiFieldsForConstructor, allSelectedPsiFields);
+        bestConstructor = mock(PsiMethod.class);
+        psiFieldsForBuilder = new PsiFieldsForBuilder(psiFieldsForSetters, psiFieldsForConstructor, allSelectedPsiFields, bestConstructor);
     }
 
     @Test
-    public void shouldGetThreeListsOfFields() {
+    public void shouldGetThreeListsOfFieldsAndBestConstructor() {
         assertThat(psiFieldsForBuilder.getFieldsForSetters()).isEqualTo(psiFieldsForSetters);
         assertThat(psiFieldsForBuilder.getFieldsForConstructor()).isEqualTo(psiFieldsForConstructor);
         assertThat(psiFieldsForBuilder.getAllSelectedFields()).isEqualTo(allSelectedPsiFields);
+        assertThat(psiFieldsForBuilder.getBestContructor()).isEqualTo(bestConstructor);
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -56,5 +60,14 @@ public class PsiFieldsForBuilderTest {
 
         // when
         fieldsForConstructor.remove(0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldThrowExceptionWhenTryingToModifyAllSelectedFieldsList() {
+        // given
+        List<PsiField> allSelectedFields = psiFieldsForBuilder.getAllSelectedFields();
+
+        // when
+        allSelectedFields.remove(0);
     }
 }

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterRunnableTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterRunnableTest.java
@@ -11,7 +11,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import pl.mjedynak.idea.plugins.builder.psi.BuilderPsiClassBuilder;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -46,8 +46,8 @@ public class BuilderWriterRunnableTest {
         // then
         ArgumentCaptor<BuilderWriterComputable> builderWriterComputableArgumentCaptor = ArgumentCaptor.forClass(BuilderWriterComputable.class);
         verify(application).runWriteAction(builderWriterComputableArgumentCaptor.capture());
-        assertEquals(builderPsiClassBuilder, getField(builderWriterComputableArgumentCaptor.getValue(), "builderPsiClassBuilder"));
-        assertEquals(context, getField(builderWriterComputableArgumentCaptor.getValue(), "context"));
-        assertEquals(existingBuilder, getField(builderWriterComputableArgumentCaptor.getValue(), "existingBuilder"));
+        assertThat(getField(builderWriterComputableArgumentCaptor.getValue(), "builderPsiClassBuilder")).isEqualTo(builderPsiClassBuilder);
+        assertThat(getField(builderWriterComputableArgumentCaptor.getValue(), "context")).isEqualTo(context);
+        assertThat(getField(builderWriterComputableArgumentCaptor.getValue(), "existingBuilder")).isEqualTo(existingBuilder);
     }
 }

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterTest.java
@@ -12,7 +12,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import pl.mjedynak.idea.plugins.builder.psi.BuilderPsiClassBuilder;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -42,8 +42,8 @@ public class BuilderWriterTest {
         // then
         ArgumentCaptor<BuilderWriterRunnable> builderWriterRunnableArgumentCaptor = ArgumentCaptor.forClass(BuilderWriterRunnable.class);
         verify(commandProcessor).executeCommand(eq(project), builderWriterRunnableArgumentCaptor.capture(), eq(BuilderWriter.CREATE_BUILDER_STRING), eq(builderWriter));
-        assertEquals(builderPsiClassBuilder, getField(builderWriterRunnableArgumentCaptor.getValue(), "builderPsiClassBuilder"));
-        assertEquals(context, getField(builderWriterRunnableArgumentCaptor.getValue(), "context"));
-        assertEquals(existingBuilder, getField(builderWriterRunnableArgumentCaptor.getValue(), "existingBuilder"));
+        assertThat(getField(builderWriterRunnableArgumentCaptor.getValue(), "builderPsiClassBuilder")).isEqualTo(builderPsiClassBuilder);
+        assertThat(getField(builderWriterRunnableArgumentCaptor.getValue(), "context")).isEqualTo(context);
+        assertThat(getField(builderWriterRunnableArgumentCaptor.getValue(), "existingBuilder")).isEqualTo(existingBuilder);
     }
 }


### PR DESCRIPTION
This commits adds a BestContructorSelector to prevent generation of faulty constructor in the built() method.

This addresses missorted parameters case (issue #35 and also https://plugins.jetbrains.com/plugin/6585-builder-generator#comment=18490) and other tricky cases like multiple constructors, or when the constructor parameter list does not match the selected fields.

Description :
First, the BestContructorSelector algorithm looks for a constructor that matches exactly the fields to be set by constructor.
If the search fails, it looks for the constructor that have all needed fields plus extra ones, and the lowest parameter count.
If the search fails, it looks for the constructor, that have the most of needed fields, and the lowest parameter count.
If no constructor is found (null returned), it means that the default constructor is the best constructor.

If the best constructor found has extra parameters, a specific method fills up the extra parameters with default values according to the type.

Other improvements and bugfixes:
  - When using Use Single Field, the source class must have zero args constructor available. If no a specific message is displayed and the creation is refused.
  - If no fields are set by setters or assignments in the build() method, the constructor is output inline with the return statement (issue #26).

Code cleanup:
Replaced usage of org.junit.Assert I introduced in my previous commits, by org.assertj.core.api.Assertions for the sake of consistency.

Checkstyle:
  - Added to suppressions.xml MagicNumberCheck for all test files
  - Added to suppressions.xml all checks for MemberChooser.java and removed checkstyle occurrences in MemberChooser.java itself
  - The checkstyle plugin in build.gradle can be restored, as the build is now OK with the previous settings