### PR TITLE
Pull Request: Added user defaults settings implementation

### DIFF
--- a/src/main/java/pl/mjedynak/idea/plugins/builder/factory/CreateBuilderDialogFactory.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/factory/CreateBuilderDialogFactory.java
@@ -6,16 +6,17 @@ import com.intellij.psi.PsiPackage;
 import pl.mjedynak.idea.plugins.builder.gui.CreateBuilderDialog;
 import pl.mjedynak.idea.plugins.builder.gui.helper.GuiHelper;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
+import pl.mjedynak.idea.plugins.builder.settings.BuilderGeneratorSettingsState;
 
 public class CreateBuilderDialogFactory {
 
-    private static final String BUILDER_SUFFIX = "Builder";
-    private static final String METHOD_PREFIX = "with";
-    private static final String DIALOG_NAME = "CreateBuilder";
+    private static String BUILDER_SUFFIX = "Builder";
+    private static String DIALOG_NAME = "CreateBuilder";
 
     private PsiHelper psiHelper;
     private ReferenceEditorComboWithBrowseButtonFactory referenceEditorComboWithBrowseButtonFactory;
     private GuiHelper guiHelper;
+
 
     public CreateBuilderDialogFactory(PsiHelper psiHelper, ReferenceEditorComboWithBrowseButtonFactory referenceEditorComboWithBrowseButtonFactory, GuiHelper guiHelper) {
         this.psiHelper = psiHelper;
@@ -24,7 +25,7 @@ public class CreateBuilderDialogFactory {
     }
 
     public CreateBuilderDialog createBuilderDialog(PsiClass sourceClass, Project project, PsiPackage srcPackage, PsiClass existingBuilder) {
-        return new CreateBuilderDialog(project, DIALOG_NAME, sourceClass, sourceClass.getName() + BUILDER_SUFFIX, METHOD_PREFIX, srcPackage, psiHelper, guiHelper,
+        return new CreateBuilderDialog(project, DIALOG_NAME, sourceClass, sourceClass.getName() + BUILDER_SUFFIX, srcPackage, psiHelper, guiHelper,
                 referenceEditorComboWithBrowseButtonFactory, existingBuilder);
     }
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialog.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialog.java
@@ -25,6 +25,7 @@ import pl.mjedynak.idea.plugins.builder.factory.PackageChooserDialogFactory;
 import pl.mjedynak.idea.plugins.builder.factory.ReferenceEditorComboWithBrowseButtonFactory;
 import pl.mjedynak.idea.plugins.builder.gui.helper.GuiHelper;
 import pl.mjedynak.idea.plugins.builder.psi.PsiHelper;
+import pl.mjedynak.idea.plugins.builder.settings.BuilderGeneratorSettingsState;
 
 import javax.swing.Action;
 import javax.swing.JCheckBox;
@@ -50,6 +51,8 @@ public class CreateBuilderDialog extends DialogWrapper {
     static final String RECENTS_KEY = "CreateBuilderDialog.RecentsKey";
     private static final int WIDTH = 40;
 
+    private static BuilderGeneratorSettingsState defaultStates = BuilderGeneratorSettingsState.getInstance();
+
     private PsiHelper psiHelper;
     private GuiHelper guiHelper;
     private Project project;
@@ -63,11 +66,11 @@ public class CreateBuilderDialog extends DialogWrapper {
     private ReferenceEditorComboWithBrowseButton targetPackageField;
     private PsiClass existingBuilder;
 
+
     public CreateBuilderDialog(Project project,
                                String title,
                                PsiClass sourceClass,
                                String targetClassName,
-                               String methodPrefix,
                                PsiPackage targetPackage,
                                PsiHelper psiHelper,
                                GuiHelper guiHelper,
@@ -80,7 +83,7 @@ public class CreateBuilderDialog extends DialogWrapper {
         this.sourceClass = sourceClass;
         this.existingBuilder = existingBuilder;
         targetClassNameField = new JTextField(targetClassName);
-        targetMethodPrefix = new JTextField(methodPrefix);
+        targetMethodPrefix = new JTextField(defaultStates.defaultMethodPrefix);
         setPreferredSize(targetClassNameField);
         setPreferredSize(targetMethodPrefix);
 
@@ -198,6 +201,7 @@ public class CreateBuilderDialog extends DialogWrapper {
         gbConstraints.anchor = GridBagConstraints.WEST;
 
         innerBuilder = new JCheckBox();
+        innerBuilder.setSelected(defaultStates.isInnerBuilder);
         innerBuilder.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -224,6 +228,7 @@ public class CreateBuilderDialog extends DialogWrapper {
         gbConstraints.fill = GridBagConstraints.HORIZONTAL;
         gbConstraints.anchor = GridBagConstraints.WEST;
         butMethod = new JCheckBox();
+        butMethod.setSelected(defaultStates.isButMethod);
         panel.add(butMethod, gbConstraints);
         // but method
 
@@ -244,6 +249,7 @@ public class CreateBuilderDialog extends DialogWrapper {
         gbConstraints.fill = GridBagConstraints.HORIZONTAL;
         gbConstraints.anchor = GridBagConstraints.WEST;
         useSingleField = new JCheckBox();
+        useSingleField.setSelected(defaultStates.isUseSinglePrefix);
         panel.add(useSingleField, gbConstraints);
         // useSingleField
 

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsComponent.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsComponent.java
@@ -1,0 +1,70 @@
+package pl.mjedynak.idea.plugins.builder.settings;
+
+
+import com.intellij.ui.components.JBCheckBox;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.util.ui.FormBuilder;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class BuilderGeneratorSettingsComponent {
+
+        private final JPanel myMainPanel;
+        private final JBTextField defaultMethodPrefixText = new JBTextField();
+        private final JBCheckBox innerBuilderCheckBox = new JBCheckBox("Inner builder");
+        private final JBCheckBox butMethodCheckBox = new JBCheckBox("'but' method'");
+        private final JBCheckBox useSinglePrefixCheckBox = new JBCheckBox("Use single prefix");
+
+        public BuilderGeneratorSettingsComponent() {
+            myMainPanel = FormBuilder.createFormBuilder()
+                    .addLabeledComponent(new JBLabel("Default prefix: "), defaultMethodPrefixText, 1, false)
+                    .addComponent(innerBuilderCheckBox, 1)
+                    .addComponent(butMethodCheckBox, 1)
+                    .addComponent(useSinglePrefixCheckBox, 1)
+                    .addComponentFillVertically(new JPanel(), 0)
+                    .getPanel();
+        }
+
+        public JPanel getPanel() {
+            return myMainPanel;
+        }
+
+        public JComponent getPreferredFocusedComponent() {
+            return defaultMethodPrefixText;
+        }
+
+        @NotNull
+        public String getDefaultMethodPrefixText() {
+            return defaultMethodPrefixText.getText();
+        }
+
+        public void setDefaultMethodPrefixText(@NotNull String newText) {
+            defaultMethodPrefixText.setText(newText);
+        }
+
+        public boolean isInnerBuilder() {
+            return innerBuilderCheckBox.isSelected();
+        }
+
+        public void setInnerBuilder(boolean isInnerBuilder) {
+            innerBuilderCheckBox.setSelected(isInnerBuilder);
+        }
+
+        public boolean isButMethod() {
+            return butMethodCheckBox.isSelected();
+        }
+
+        public void setButMethod(boolean isButMethod) {
+            butMethodCheckBox.setSelected(isButMethod);
+        }
+
+        public boolean isUseSinglePrefix() {
+            return useSinglePrefixCheckBox.isSelected();
+        }
+
+        public void setUseSinglePrefix(boolean isUseSinglePrefix) {
+            useSinglePrefixCheckBox.setSelected(isUseSinglePrefix);
+        }
+    }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsConfigurable.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsConfigurable.java
@@ -1,0 +1,67 @@
+package pl.mjedynak.idea.plugins.builder.settings;
+
+import com.intellij.openapi.options.Configurable;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class BuilderGeneratorSettingsConfigurable implements Configurable {
+
+    private BuilderGeneratorSettingsComponent mySettingsComponent;
+
+    // A default constructor with no arguments is required because this implementation
+    // is registered as an applicationConfigurable EP
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    @Override
+    public String getDisplayName() {
+        return "SDK: Application Settings Example";
+    }
+
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return mySettingsComponent.getPreferredFocusedComponent();
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        mySettingsComponent = new BuilderGeneratorSettingsComponent();
+        return mySettingsComponent.getPanel();
+    }
+
+    @Override
+    public boolean isModified() {
+        BuilderGeneratorSettingsState settings = BuilderGeneratorSettingsState.getInstance();
+        boolean modified = !mySettingsComponent.getDefaultMethodPrefixText().equals(settings.defaultMethodPrefix);
+        modified |= mySettingsComponent.isInnerBuilder() != settings.isInnerBuilder;
+        modified |= mySettingsComponent.isButMethod() != settings.isButMethod;
+        modified |= mySettingsComponent.isUseSinglePrefix() != settings.isUseSinglePrefix;
+        return modified;
+    }
+
+    @Override
+    public void apply() {
+        BuilderGeneratorSettingsState settings = BuilderGeneratorSettingsState.getInstance();
+        settings.defaultMethodPrefix = mySettingsComponent.getDefaultMethodPrefixText();
+        settings.isInnerBuilder = mySettingsComponent.isInnerBuilder();
+        settings.isButMethod = mySettingsComponent.isButMethod();
+        settings.isUseSinglePrefix = mySettingsComponent.isUseSinglePrefix();
+    }
+
+    @Override
+    public void reset() {
+        BuilderGeneratorSettingsState settings = BuilderGeneratorSettingsState.getInstance();
+        mySettingsComponent.setDefaultMethodPrefixText(settings.defaultMethodPrefix);
+        mySettingsComponent.setInnerBuilder(settings.isInnerBuilder);
+        mySettingsComponent.setButMethod(settings.isButMethod);
+        mySettingsComponent.setUseSinglePrefix(settings.isUseSinglePrefix);
+    }
+
+    @Override
+    public void disposeUIResources() {
+        mySettingsComponent = null;
+    }
+
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsState.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsState.java
@@ -1,0 +1,48 @@
+package pl.mjedynak.idea.plugins.builder.settings;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Supports storing the application settings in a persistent way.
+ * The {@link State} and {@link Storage} annotations define the name of the data and the file name where
+ * these persistent application settings are stored.
+ */
+@State(
+        name = "org.intellij.sdk.settings.AppSettingsState",
+        storages = @Storage("SdkSettingsPlugin.xml")
+)
+public class BuilderGeneratorSettingsState implements PersistentStateComponent<BuilderGeneratorSettingsState> {
+
+    public String defaultMethodPrefix = "with";
+    public boolean isInnerBuilder = false;
+    public boolean isButMethod = false;
+    public boolean isUseSinglePrefix = false;
+
+    public BuilderGeneratorSettingsState() {}
+
+    public static BuilderGeneratorSettingsState getInstance() {
+        try {
+            return ApplicationManager.getApplication().getService(BuilderGeneratorSettingsState.class);
+        } catch (NullPointerException e) {
+            return new BuilderGeneratorSettingsState();
+        }
+    }
+
+    @Nullable
+    @Override
+    public BuilderGeneratorSettingsState getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(@NotNull BuilderGeneratorSettingsState state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -177,6 +177,12 @@
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">
-
+        <applicationService
+            serviceImplementation="pl.mjedynak.idea.plugins.builder.settings.BuilderGeneratorSettingsState"/>
+        <applicationConfigurable
+                parentId="tools"
+                instance="pl.mjedynak.idea.plugins.builder.settings.BuilderGeneratorSettingsConfigurable"
+                id="pl.mjedynak.idea.plugins.builder.settings.BuilderGeneratorSettingsConfigurable"
+                displayName="Builder Generation Defaults"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Hey. Thanks for the plugin. Super useful! I wanted the ability to have different defaults so I implemented that.

For example. I quite like to have _no prefix_ and  set _Inner Class true_.
<img src="https://i.gyazo.com/97a4fa8efbfd9e7fb380ea684829a626.png" data-canonical-src="https://i.gyazo.com/97a4fa8efbfd9e7fb380ea684829a626.png" width="580" height="400" />

Your tests are passing locally and I can see the settings persist in this pr.

I'm also probably going to add a optional checkbox in my fork later to only generate the methods. Similar to your legacy Fluent setter methods. & add an option to generate builder **and** getters &  setters all at once if I can. Let me know your thoughts