### PR TITLE
Make builder method parameters final by default

### DIFF
--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/MethodCreator.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/MethodCreator.java
@@ -28,10 +28,10 @@ public class MethodCreator {
         String methodText;
         if(useSingleField){
             String setterName = methodNameCreator.createMethodName("set", fieldNameWithoutPrefix);
-            methodText = "public " + builderClassName + " " + methodName + "(" + fieldType + " " + parameterName + ") { "
+            methodText = "public " + builderClassName + " " + methodName + "(final " + fieldType + " " + parameterName + ") { "
                 + srcClassFieldName + "." + setterName + "(" + fieldName + "); return this; }";
         } else {
-            methodText = "public " + builderClassName + " " + methodName + "(" + fieldType + " " + parameterName + ") { this."
+            methodText = "public " + builderClassName + " " + methodName + "(final " + fieldType + " " + parameterName + ") { this."
                 + fieldName + " = " + parameterName + "; return this; }";
         }
         return elementFactory.createMethodFromText(methodText, psiField);

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/psi/MethodCreatorTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/psi/MethodCreatorTest.java
@@ -49,7 +49,7 @@ public class MethodCreatorTest {
     void shouldCreateMethod() {
         // given
         initOtherCommonMocks();
-        given(elementFactory.createMethodFromText("public BuilderClassName withName(String name) { this.name = name; return this; }", psiField)).willReturn(method);
+        given(elementFactory.createMethodFromText("public BuilderClassName withName(final String name) { this.name = name; return this; }", psiField)).willReturn(method);
         String methodPrefix = "with";
 
         // when
@@ -64,7 +64,7 @@ public class MethodCreatorTest {
         // given
         initOtherCommonMocks();
         given(methodNameCreator.createMethodName("set", "name")).willReturn("setName");
-        given(elementFactory.createMethodFromText("public BuilderClassName withName(String name) { className.setName(name); return this; }", psiField)).willReturn(method);
+        given(elementFactory.createMethodFromText("public BuilderClassName withName(final String name) { className.setName(name); return this; }", psiField)).willReturn(method);
         String methodPrefix = "with";
 
         // when


### PR DESCRIPTION
Small PR to make the builder method parameters final by default. 