### PR TITLE
Add ability to create a copy constructor

### DIFF
--- a/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosers.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/action/handler/DisplayChoosers.java
@@ -65,7 +65,7 @@ public class DisplayChoosers {
             List<PsiElementClassMember> selectedElements = memberChooserDialog.getSelectedElements();
             PsiFieldsForBuilder psiFieldsForBuilder = psiFieldsForBuilderFactory.createPsiFieldsForBuilder(selectedElements, psiClassFromEditor);
             BuilderContext context = new BuilderContext(
-                    project, psiFieldsForBuilder, targetDirectory, className, psiClassFromEditor, methodPrefix, createBuilderDialog.isInnerBuilder(), createBuilderDialog.hasButMethod(), createBuilderDialog.useSingleField());
+                    project, psiFieldsForBuilder, targetDirectory, className, psiClassFromEditor, methodPrefix, createBuilderDialog.isInnerBuilder(), createBuilderDialog.hasButMethod(), createBuilderDialog.useSingleField(), createBuilderDialog.hasAddCopyConstructor());
             builderWriter.writeBuilder(context, existingBuilder);
         }
     }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialog.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialog.java
@@ -232,7 +232,6 @@ public class CreateBuilderDialog extends DialogWrapper {
         panel.add(butMethod, gbConstraints);
         // but method
 
-
         // useSingleField
         gbConstraints.insets = new Insets(4, 8, 4, 8);
         gbConstraints.gridx = 0;

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialog.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/gui/CreateBuilderDialog.java
@@ -63,6 +63,7 @@ public class CreateBuilderDialog extends DialogWrapper {
     private JCheckBox innerBuilder;
     private JCheckBox butMethod;
     private JCheckBox useSingleField;
+    private JCheckBox copyConstructor;
     private ReferenceEditorComboWithBrowseButton targetPackageField;
     private PsiClass existingBuilder;
 
@@ -211,7 +212,6 @@ public class CreateBuilderDialog extends DialogWrapper {
         panel.add(innerBuilder, gbConstraints);
         // Inner builder
 
-
         // but method
         gbConstraints.insets = new Insets(4, 8, 4, 8);
         gbConstraints.gridx = 0;
@@ -252,6 +252,26 @@ public class CreateBuilderDialog extends DialogWrapper {
         useSingleField.setSelected(defaultStates.isUseSinglePrefix);
         panel.add(useSingleField, gbConstraints);
         // useSingleField
+
+        // copy constructor
+        gbConstraints.insets = new Insets(4, 8, 4, 8);
+        gbConstraints.gridx = 0;
+        gbConstraints.weightx = 0;
+        gbConstraints.gridy = 7;
+        gbConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gbConstraints.anchor = GridBagConstraints.WEST;
+        panel.add(new JLabel("Add copy constructor"), gbConstraints);
+
+        gbConstraints.insets = new Insets(4, 8, 4, 8);
+        gbConstraints.gridx = 1;
+        gbConstraints.weightx = 1;
+        gbConstraints.gridwidth = 1;
+        gbConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gbConstraints.anchor = GridBagConstraints.WEST;
+        copyConstructor = new JCheckBox();
+        copyConstructor.setSelected(defaultStates.isAddCopyConstructor);
+        panel.add(copyConstructor, gbConstraints);
+        // copy constructor
 
         return panel;
     }
@@ -345,6 +365,10 @@ public class CreateBuilderDialog extends DialogWrapper {
 
     public boolean useSingleField() {
         return useSingleField.isSelected();
+    }
+
+    public boolean hasAddCopyConstructor() {
+        return copyConstructor.isSelected();
     }
 
     public PsiDirectory getTargetDirectory() {

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilder.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilder.java
@@ -1,14 +1,6 @@
 package pl.mjedynak.idea.plugins.builder.psi;
 
-import com.intellij.psi.JavaDirectoryService;
-import com.intellij.psi.JavaPsiFacade;
-import com.intellij.psi.PsiClass;
-import com.intellij.psi.PsiElementFactory;
-import com.intellij.psi.PsiField;
-import com.intellij.psi.PsiMethod;
-import com.intellij.psi.PsiModifierList;
-import com.intellij.psi.PsiParameter;
-import com.intellij.psi.PsiType;
+import com.intellij.psi.*;
 import org.apache.commons.lang.StringUtils;
 import pl.mjedynak.idea.plugins.builder.settings.CodeStyleSettings;
 import pl.mjedynak.idea.plugins.builder.verifier.PsiFieldVerifier;
@@ -24,7 +16,6 @@ import static com.intellij.openapi.util.text.StringUtil.isVowel;
 
 public class BuilderPsiClassBuilder {
 
-    private static final String PRIVATE_STRING = "private";
     private static final String SPACE = " ";
     private static final String A_PREFIX = " a";
     private static final String AN_PREFIX = " an";
@@ -105,14 +96,14 @@ public class BuilderPsiClassBuilder {
         return this;
     }
 
-    public BuilderPsiClassBuilder withPrivateConstructor() {
+    public BuilderPsiClassBuilder withConstructor() {
         PsiMethod constructor;
         if (useSingleField) {
             constructor = elementFactory.createMethodFromText(builderClassName + "(){ " + srcClassFieldName + " = new " + srcClassName + "(); }", srcClass);
         } else {
             constructor = elementFactory.createConstructor();
         }
-        constructor.getModifierList().setModifierProperty(PRIVATE_STRING, true);
+        constructor.getModifierList().setModifierProperty(PsiModifier.PUBLIC, true);
         builderClass.add(constructor);
         return this;
     }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilder.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilder.java
@@ -37,6 +37,7 @@ public class BuilderPsiClassBuilder {
     private PsiFieldVerifier psiFieldVerifier = new PsiFieldVerifier();
     private CodeStyleSettings codeStyleSettings = new CodeStyleSettings();
     private ButMethodCreator butMethodCreator;
+    private CopyConstructorCreator copyConstructorCreator;
     private MethodCreator methodCreator;
 
     private PsiClass srcClass = null;
@@ -87,6 +88,7 @@ public class BuilderPsiClassBuilder {
         bestConstructor = context.getPsiFieldsForBuilder().getBestConstructor();
         methodCreator = new MethodCreator(elementFactory, builderClassName);
         butMethodCreator = new ButMethodCreator(elementFactory);
+        copyConstructorCreator = new CopyConstructorCreator(elementFactory);
         isInline = allSelectedPsiFields.size() == psiFieldsForConstructor.size();
     }
 
@@ -145,6 +147,12 @@ public class BuilderPsiClassBuilder {
 
     public BuilderPsiClassBuilder withButMethod() {
         PsiMethod method = butMethodCreator.butMethod(builderClassName, builderClass, srcClass, srcClassFieldName, useSingleField);
+        builderClass.add(method);
+        return this;
+    }
+
+    public BuilderPsiClassBuilder withCopyConstructor() {
+        final PsiMethod method = copyConstructorCreator.copyConstructor(builderClassName, builderClass, srcClass);
         builderClass.add(method);
         return this;
     }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilder.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilder.java
@@ -152,7 +152,7 @@ public class BuilderPsiClassBuilder {
     }
 
     public BuilderPsiClassBuilder withCopyConstructor() {
-        final PsiMethod method = copyConstructorCreator.copyConstructor(builderClassName, builderClass, srcClass);
+        final PsiMethod method = copyConstructorCreator.copyConstructor(builderClass, srcClass, isInnerBuilder(builderClass));
         builderClass.add(method);
         return this;
     }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/CopyConstructorCreator.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/CopyConstructorCreator.java
@@ -43,7 +43,7 @@ public class CopyConstructorCreator {
             return method;
         }
 
-        throw new IncorrectOperationException("Cannot find getter for fields");
+        throw new IncorrectOperationException("Could not create copy constructor as cannot get field getters");
     }
 
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/psi/CopyConstructorCreator.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/psi/CopyConstructorCreator.java
@@ -1,0 +1,29 @@
+package pl.mjedynak.idea.plugins.builder.psi;
+
+import com.intellij.psi.*;
+
+import java.util.Arrays;
+
+public class CopyConstructorCreator {
+
+    private final PsiElementFactory elementFactory;
+
+    public CopyConstructorCreator(final PsiElementFactory elementFactory) {
+        this.elementFactory = elementFactory;
+    }
+
+    public PsiMethod copyConstructor(final String builderClassName, final PsiClass builderClass, final PsiClass srcClass) {
+        final PsiField[] fields = builderClass.getAllFields();
+        final StringBuilder text = new StringBuilder("public " + builderClassName + "(" + srcClass.getQualifiedName() + " other) { ");
+        Arrays.stream(fields).forEach( field -> {
+            if (srcClass.isRecord()) {
+                text.append("this.").append(field.getName()).append(" = other.").append(field.getName()).append("();");
+            } else {
+                text.append("this.").append(field.getName()).append(" = other.").append(field.getName()).append(";");
+            }
+        });
+        text.append(" }");
+        return elementFactory.createMethodFromText(text.toString(), srcClass);
+    }
+
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsComponent.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsComponent.java
@@ -11,60 +11,74 @@ import javax.swing.*;
 
 public class BuilderGeneratorSettingsComponent {
 
-        private final JPanel myMainPanel;
-        private final JBTextField defaultMethodPrefixText = new JBTextField();
-        private final JBCheckBox innerBuilderCheckBox = new JBCheckBox("Inner builder");
-        private final JBCheckBox butMethodCheckBox = new JBCheckBox("'but' method'");
-        private final JBCheckBox useSinglePrefixCheckBox = new JBCheckBox("Use single prefix");
+    private final JPanel myMainPanel;
+    private final JBTextField defaultMethodPrefixText = new JBTextField();
+    private final JBCheckBox innerBuilderCheckBox = new JBCheckBox("Inner builder");
+    private final JBCheckBox butMethodCheckBox = new JBCheckBox("'but' method'");
+    private final JBCheckBox useSinglePrefixCheckBox = new JBCheckBox("Use single prefix");
+    private final JBCheckBox addCopyConstructorCheckBox = new JBCheckBox("Add copy constructor");
 
-        public BuilderGeneratorSettingsComponent() {
-            myMainPanel = FormBuilder.createFormBuilder()
-                    .addLabeledComponent(new JBLabel("Default prefix: "), defaultMethodPrefixText, 1, false)
-                    .addComponent(innerBuilderCheckBox, 1)
-                    .addComponent(butMethodCheckBox, 1)
-                    .addComponent(useSinglePrefixCheckBox, 1)
-                    .addComponentFillVertically(new JPanel(), 0)
-                    .getPanel();
-        }
-
-        public JPanel getPanel() {
-            return myMainPanel;
-        }
-
-        public JComponent getPreferredFocusedComponent() {
-            return defaultMethodPrefixText;
-        }
-
-        @NotNull
-        public String getDefaultMethodPrefixText() {
-            return defaultMethodPrefixText.getText();
-        }
-
-        public void setDefaultMethodPrefixText(@NotNull String newText) {
-            defaultMethodPrefixText.setText(newText);
-        }
-
-        public boolean isInnerBuilder() {
-            return innerBuilderCheckBox.isSelected();
-        }
-
-        public void setInnerBuilder(boolean isInnerBuilder) {
-            innerBuilderCheckBox.setSelected(isInnerBuilder);
-        }
-
-        public boolean isButMethod() {
-            return butMethodCheckBox.isSelected();
-        }
-
-        public void setButMethod(boolean isButMethod) {
-            butMethodCheckBox.setSelected(isButMethod);
-        }
-
-        public boolean isUseSinglePrefix() {
-            return useSinglePrefixCheckBox.isSelected();
-        }
-
-        public void setUseSinglePrefix(boolean isUseSinglePrefix) {
-            useSinglePrefixCheckBox.setSelected(isUseSinglePrefix);
-        }
+    public BuilderGeneratorSettingsComponent() {
+        myMainPanel = FormBuilder.createFormBuilder()
+                .addLabeledComponent(new JBLabel("Default prefix: "), defaultMethodPrefixText, 1, false)
+                .addComponent(innerBuilderCheckBox, 1)
+                .addComponent(butMethodCheckBox, 1)
+                .addComponent(useSinglePrefixCheckBox, 1)
+                .addComponent(addCopyConstructorCheckBox, 1)
+                .addComponentFillVertically(new JPanel(), 0)
+                .getPanel();
     }
+
+    public JPanel getPanel() {
+        return myMainPanel;
+    }
+
+    public JComponent getPreferredFocusedComponent() {
+        return defaultMethodPrefixText;
+    }
+
+    @NotNull
+    public String getDefaultMethodPrefixText() {
+        return defaultMethodPrefixText.getText();
+    }
+
+    public void setDefaultMethodPrefixText(@NotNull String newText) {
+        defaultMethodPrefixText.setText(newText);
+    }
+
+    public boolean isInnerBuilder() {
+        return innerBuilderCheckBox.isSelected();
+    }
+
+    public void setInnerBuilder(boolean isInnerBuilder) {
+        innerBuilderCheckBox.setSelected(isInnerBuilder);
+    }
+
+    public boolean isButMethod() {
+        return butMethodCheckBox.isSelected();
+    }
+
+    public void setButMethod(boolean isButMethod) {
+        butMethodCheckBox.setSelected(isButMethod);
+    }
+
+    public boolean isUseSinglePrefix() {
+        return useSinglePrefixCheckBox.isSelected();
+    }
+
+    public void setUseSinglePrefix(boolean isUseSinglePrefix) {
+        useSinglePrefixCheckBox.setSelected(isUseSinglePrefix);
+    }
+
+    public boolean isAddCopyConstructor() {
+        return addCopyConstructorCheckBox.isSelected();
+    }
+
+    public void setAddCopyConstructor(boolean addCopyConstructor) {
+        addCopyConstructorCheckBox.setSelected(addCopyConstructor);
+    }
+
+    public void setAddCopyConstructorEnabled(boolean enabled) {
+        addCopyConstructorCheckBox.setEnabled(enabled);
+    }
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsConfigurable.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsConfigurable.java
@@ -38,6 +38,7 @@ public class BuilderGeneratorSettingsConfigurable implements Configurable {
         modified |= mySettingsComponent.isInnerBuilder() != settings.isInnerBuilder;
         modified |= mySettingsComponent.isButMethod() != settings.isButMethod;
         modified |= mySettingsComponent.isUseSinglePrefix() != settings.isUseSinglePrefix;
+        modified |= mySettingsComponent.isAddCopyConstructor() != settings.isAddCopyConstructor;
         return modified;
     }
 
@@ -48,6 +49,7 @@ public class BuilderGeneratorSettingsConfigurable implements Configurable {
         settings.isInnerBuilder = mySettingsComponent.isInnerBuilder();
         settings.isButMethod = mySettingsComponent.isButMethod();
         settings.isUseSinglePrefix = mySettingsComponent.isUseSinglePrefix();
+        settings.isAddCopyConstructor = mySettingsComponent.isAddCopyConstructor();
     }
 
     @Override
@@ -57,6 +59,7 @@ public class BuilderGeneratorSettingsConfigurable implements Configurable {
         mySettingsComponent.setInnerBuilder(settings.isInnerBuilder);
         mySettingsComponent.setButMethod(settings.isButMethod);
         mySettingsComponent.setUseSinglePrefix(settings.isUseSinglePrefix);
+        mySettingsComponent.setAddCopyConstructor(settings.isAddCopyConstructor);
     }
 
     @Override

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsState.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/settings/BuilderGeneratorSettingsState.java
@@ -23,6 +23,7 @@ public class BuilderGeneratorSettingsState implements PersistentStateComponent<B
     public boolean isInnerBuilder = false;
     public boolean isButMethod = false;
     public boolean isUseSinglePrefix = false;
+    public boolean isAddCopyConstructor = false;
 
     public BuilderGeneratorSettingsState() {}
 

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderContext.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderContext.java
@@ -17,10 +17,12 @@ public class BuilderContext {
     private final boolean isInner;
     private final boolean hasButMethod;
     private final boolean useSingleField;
+    private final boolean addCopyConstructor;
 
     public BuilderContext(Project project, PsiFieldsForBuilder psiFieldsForBuilder,
                           PsiDirectory targetDirectory, String className, PsiClass psiClassFromEditor,
-                          String methodPrefix, boolean isInner, boolean hasButMethod, boolean useSingleField) {
+                          String methodPrefix, boolean isInner, boolean hasButMethod, boolean useSingleField,
+                          boolean addCopyConstructor) {
         this.project = project;
         this.psiFieldsForBuilder = psiFieldsForBuilder;
         this.targetDirectory = targetDirectory;
@@ -30,6 +32,7 @@ public class BuilderContext {
         this.isInner = isInner;
         this.hasButMethod = hasButMethod;
         this.useSingleField = useSingleField;
+        this.addCopyConstructor = addCopyConstructor;
     }
 
     public Project getProject() {
@@ -66,6 +69,10 @@ public class BuilderContext {
 
     public boolean useSingleField() {
         return useSingleField;
+    }
+
+    public boolean hasAddCopyConstructor() {
+        return addCopyConstructor;
     }
 
     @Override

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputable.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputable.java
@@ -54,7 +54,7 @@ class BuilderWriterComputable implements Computable<PsiElement> {
     private PsiClass getInnerBuilderPsiClass() {
         BuilderPsiClassBuilder builder = builderPsiClassBuilder.anInnerBuilder(context)
                 .withFields()
-                .withPrivateConstructor()
+                .withConstructor()
                 .withInitializingMethod()
                 .withSetMethods(context.getMethodPrefix());
         addButMethodIfNecessary(builder);
@@ -65,7 +65,7 @@ class BuilderWriterComputable implements Computable<PsiElement> {
     private PsiClass getBuilderPsiClass() {
         BuilderPsiClassBuilder builder = builderPsiClassBuilder.aBuilder(context)
                 .withFields()
-                .withPrivateConstructor()
+                .withConstructor()
                 .withInitializingMethod()
                 .withSetMethods(context.getMethodPrefix());
         addButMethodIfNecessary(builder);

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputable.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputable.java
@@ -56,7 +56,8 @@ class BuilderWriterComputable implements Computable<PsiElement> {
                 .withFields()
                 .withPrivateConstructor()
                 .withInitializingMethod()
-                .withSetMethods(context.getMethodPrefix());
+                .withSetMethods(context.getMethodPrefix())
+                .withCopyConstructor();
         addButMethodIfNecessary(builder);
         return builder.build();
     }
@@ -66,7 +67,8 @@ class BuilderWriterComputable implements Computable<PsiElement> {
                 .withFields()
                 .withPrivateConstructor()
                 .withInitializingMethod()
-                .withSetMethods(context.getMethodPrefix());
+                .withSetMethods(context.getMethodPrefix())
+                .withCopyConstructor();
         addButMethodIfNecessary(builder);
         return builder.build();
     }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputable.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputable.java
@@ -45,7 +45,7 @@ class BuilderWriterComputable implements Computable<PsiElement> {
             }
             return targetClass;
         } catch (IncorrectOperationException e) {
-            showErrorMessage(context.getProject(), context.getClassName());
+            showErrorMessage(context.getProject(), context.getClassName(), e.getMessage());
             e.printStackTrace();
             return null;
         }
@@ -89,8 +89,10 @@ class BuilderWriterComputable implements Computable<PsiElement> {
         guiHelper.positionCursor(project, targetClass.getContainingFile(), targetClass.getLBrace());
     }
 
-    private void showErrorMessage(Project project, String className) {
+    private void showErrorMessage(Project project, String className, String message) {
+        BuilderWriterErrorRunnable builderWriterErrorRunnable = message == null ? new BuilderWriterErrorRunnable(project, className) : new BuilderWriterErrorRunnable(project, className, message);
+
         Application application = psiHelper.getApplication();
-        application.invokeLater(new BuilderWriterErrorRunnable(project, className));
+        application.invokeLater(builderWriterErrorRunnable);
     }
 }

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputable.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputable.java
@@ -56,9 +56,9 @@ class BuilderWriterComputable implements Computable<PsiElement> {
                 .withFields()
                 .withPrivateConstructor()
                 .withInitializingMethod()
-                .withSetMethods(context.getMethodPrefix())
-                .withCopyConstructor();
+                .withSetMethods(context.getMethodPrefix());
         addButMethodIfNecessary(builder);
+        addCopyConstructorIfNecessary(builder);
         return builder.build();
     }
 
@@ -67,15 +67,21 @@ class BuilderWriterComputable implements Computable<PsiElement> {
                 .withFields()
                 .withPrivateConstructor()
                 .withInitializingMethod()
-                .withSetMethods(context.getMethodPrefix())
-                .withCopyConstructor();
+                .withSetMethods(context.getMethodPrefix());
         addButMethodIfNecessary(builder);
+        addCopyConstructorIfNecessary(builder);
         return builder.build();
     }
 
     private void addButMethodIfNecessary(BuilderPsiClassBuilder builder) {
         if (context.hasButMethod()) {
             builder.withButMethod();
+        }
+    }
+
+    private void addCopyConstructorIfNecessary(BuilderPsiClassBuilder builder) {
+        if (context.hasAddCopyConstructor()) {
+            builder.withCopyConstructor();
         }
     }
 

--- a/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterErrorRunnable.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterErrorRunnable.java
@@ -11,16 +11,24 @@ public class BuilderWriterErrorRunnable implements Runnable {
 
     private Project project;
     private String className;
+    private String message;
 
     public BuilderWriterErrorRunnable(Project project, String className) {
         this.project = project;
         this.className = className;
+        this.message = INTENTION_ERROR_CANNOT_CREATE_CLASS_MESSAGE;
+    }
+
+    public BuilderWriterErrorRunnable(Project project, String className, String message) {
+        this.project = project;
+        this.className = className;
+        this.message = message;
     }
 
     @Override
     public void run() {
          Messages.showErrorDialog(project,
-                 CodeInsightBundle.message(INTENTION_ERROR_CANNOT_CREATE_CLASS_MESSAGE, className),
+                 CodeInsightBundle.message(message, className),
                  CodeInsightBundle.message(INTENTION_ERROR_CANNOT_CREATE_CLASS_TITLE));
     }
 }

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilderTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilderTest.java
@@ -323,7 +323,7 @@ class BuilderPsiClassBuilderTest {
     @Test
     void shouldAddConstructorMethod() {
         // given
-        given(copyConstructorCreator.copyConstructor(builderClassName, builderClass, srcClass)).willReturn(psiMethod);
+        given(copyConstructorCreator.copyConstructor(builderClass, srcClass, false)).willReturn(psiMethod);
         BuilderPsiClassBuilder builder = psiClassBuilder.aBuilder(context);
         setField(builder, "copyConstructorCreator", copyConstructorCreator);
 

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilderTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilderTest.java
@@ -166,10 +166,10 @@ class BuilderPsiClassBuilderTest {
         given(elementFactory.createConstructor()).willReturn(constructor);
 
         // when
-        psiClassBuilder.aBuilder(context).withPrivateConstructor();
+        psiClassBuilder.aBuilder(context).withConstructor();
 
         // then
-        verify(modifierList).setModifierProperty(PsiModifier.PRIVATE, true);
+        verify(modifierList).setModifierProperty(PsiModifier.PUBLIC, true);
         verify(builderClass).add(constructor);
     }
 
@@ -184,10 +184,10 @@ class BuilderPsiClassBuilderTest {
         given(elementFactory.createMethodFromText(constructorText, srcClass)).willReturn(constructor);
 
         // when
-        psiClassBuilder.aBuilder(context).withPrivateConstructor();
+        psiClassBuilder.aBuilder(context).withConstructor();
 
         // then
-        verify(modifierList).setModifierProperty(PsiModifier.PRIVATE, true);
+        verify(modifierList).setModifierProperty(PsiModifier.PUBLIC, true);
         verify(builderClass).add(constructor);
     }
 

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilderTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilderTest.java
@@ -70,7 +70,9 @@ class BuilderPsiClassBuilderTest {
     @Captor private ArgumentCaptor<String> stringCaptor;
 
     private BuilderContext createBuilderContext(boolean useSingleField) {
-        return new BuilderContext(project, psiFieldsForBuilder, targetDirectory, builderClassName, srcClass, "anyPrefix", false, false, useSingleField);
+        return new BuilderContext(
+                project, psiFieldsForBuilder, targetDirectory, builderClassName, srcClass, "anyPrefix", false, false, useSingleField, false
+        );
     }
 
     private void mockCodeStyleManager() {

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilderTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/psi/BuilderPsiClassBuilderTest.java
@@ -44,13 +44,14 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 
 @ExtendWith(MockitoExtension.class)
-public class BuilderPsiClassBuilderTest {
+class BuilderPsiClassBuilderTest {
     private static final PsiParameter[] EMPTY_PSI_PARAMETERS = {};
 
     @InjectMocks private BuilderPsiClassBuilder psiClassBuilder;
     @Mock(strictness = Mock.Strictness.LENIENT) private CodeStyleSettings settings;
     @Mock(strictness = Mock.Strictness.LENIENT) private PsiHelper psiHelper;
     @Mock private ButMethodCreator butMethodCreator;
+    @Mock private CopyConstructorCreator copyConstructorCreator;
     @Mock private MethodCreator methodCreator;
     @Mock private PsiFieldsModifier psiFieldsModifier;
     @Mock private Project project;
@@ -311,6 +312,21 @@ public class BuilderPsiClassBuilderTest {
 
         // when
         BuilderPsiClassBuilder result = builder.withButMethod();
+
+        // then
+        assertThat(result).isSameAs(psiClassBuilder);
+        verify(builderClass).add(psiMethod);
+    }
+
+    @Test
+    void shouldAddConstructorMethod() {
+        // given
+        given(copyConstructorCreator.copyConstructor(builderClassName, builderClass, srcClass)).willReturn(psiMethod);
+        BuilderPsiClassBuilder builder = psiClassBuilder.aBuilder(context);
+        setField(builder, "copyConstructorCreator", copyConstructorCreator);
+
+        // when
+        BuilderPsiClassBuilder result = builder.withCopyConstructor();
 
         // then
         assertThat(result).isSameAs(psiClassBuilder);

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/psi/CopyConstructorCreatorTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/psi/CopyConstructorCreatorTest.java
@@ -1,0 +1,50 @@
+package pl.mjedynak.idea.plugins.builder.psi;
+
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElementFactory;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiMethod;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CopyConstructorCreatorTest {
+
+    @InjectMocks
+    private CopyConstructorCreator copyConstructorCreator;
+
+    @Mock private PsiElementFactory elementFactory;
+    @Mock private PsiClass builderClass;
+    @Mock private PsiClass srcClass;
+    @Mock private PsiField psiField;
+    @Mock private PsiMethod createdMethod;
+
+    @BeforeEach
+    void beforeEach() {
+        given(srcClass.getQualifiedName()).willReturn("MyClass");
+        given(builderClass.getAllFields()).willReturn(List.of(psiField).toArray(PsiField[]::new));
+        given(psiField.getName()).willReturn("age");
+    }
+
+    @Test
+    void shouldCreateButMethod() {
+        // given
+        given(elementFactory.createMethodFromText("public Builder(MyClass other) { this.age = other.age; }", srcClass)).willReturn(createdMethod);
+
+        // when
+        final PsiMethod result = copyConstructorCreator.copyConstructor("Builder", builderClass, srcClass);
+
+        // then
+        assertThat(result).isEqualTo(createdMethod);
+    }
+
+}

--- a/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputableTest.java
+++ b/src/test/java/pl/mjedynak/idea/plugins/builder/writer/BuilderWriterComputableTest.java
@@ -100,7 +100,7 @@ public class BuilderWriterComputableTest {
 
     private void mockBuilder() {
         given(builderPsiClassBuilder.withFields()).willReturn(builderPsiClassBuilder);
-        given(builderPsiClassBuilder.withPrivateConstructor()).willReturn(builderPsiClassBuilder);
+        given(builderPsiClassBuilder.withConstructor()).willReturn(builderPsiClassBuilder);
         given(builderPsiClassBuilder.withInitializingMethod()).willReturn(builderPsiClassBuilder);
         given(builderPsiClassBuilder.withSetMethods(METHOD_PREFIX)).willReturn(builderPsiClassBuilder);
         given(builderPsiClassBuilder.build()).willReturn(builderClass);


### PR DESCRIPTION
This PR adds the ability for a copy constructor as seen below.

`    public static final class RecordABuilder {
        private String fieldOne;
        private String fieldTwo;

        private RecordABuilder() {
        }

        private RecordABuilder(RecordA recordA) {
            this.fieldOne = recordA.fieldOne();
            this.fieldTwo = recordA.fieldTwo();
        }
     ...
  }`
  
Currently an optional feature through the ui popup.